### PR TITLE
fix: allow theme flags for subcommands

### DIFF
--- a/crates/oyo/src/main.rs
+++ b/crates/oyo/src/main.rs
@@ -57,15 +57,15 @@ struct Args {
     autoplay: bool,
 
     /// Theme mode: dark or light
-    #[arg(long, value_enum)]
+    #[arg(long, value_enum, global = true)]
     theme_mode: Option<CliThemeMode>,
 
     /// Theme name (overrides config)
-    #[arg(long)]
+    #[arg(long, global = true)]
     theme_name: Option<String>,
 
     /// Syntax theme name or .tmTheme file (overrides config)
-    #[arg(long)]
+    #[arg(long, global = true)]
     syntax_theme: Option<String>,
 
     /// Dump syntax scopes for a file and exit


### PR DESCRIPTION
This pull request makes a small update to the argument definitions in the `Args` struct in `crates/oyo/src/main.rs`. The change ensures that the `theme_mode`, `theme_name`, and `syntax_theme` command-line options are available globally across subcommands.

* Added the `global = true` attribute to the `theme_mode`, `theme_name`, and `syntax_theme` arguments in the `Args` struct to make these options available for all subcommands.