### PR TITLE
fix: keep mixed modified in no-step single view

### DIFF
--- a/crates/oyo/src/views/evolution.rs
+++ b/crates/oyo/src/views/evolution.rs
@@ -23,6 +23,9 @@ const GUTTER_WIDTH: u16 = 8; // "▶1234   " (matches single-pane width)
 pub fn render_evolution(frame: &mut Frame, app: &mut App, area: Rect) {
     let visible_height = area.height as usize;
     let visible_width = area.width.saturating_sub(GUTTER_WIDTH) as usize;
+    if !app.line_wrap {
+        app.clamp_horizontal_scroll_cached(visible_width);
+    }
 
     // Clone markers to avoid borrow conflicts
     let primary_marker = app.primary_marker.clone();
@@ -350,6 +353,8 @@ pub fn render_evolution(frame: &mut Frame, app: &mut App, area: Rect) {
 
     // Clamp horizontal scroll
     app.clamp_horizontal_scroll(max_line_width, visible_width);
+
+    app.set_current_max_line_width(max_line_width);
 
     // Background style (if set)
     let bg_style = app.theme.background.map(|bg| Style::default().bg(bg));

--- a/crates/oyo/src/views/mod.rs
+++ b/crates/oyo/src/views/mod.rs
@@ -183,6 +183,10 @@ pub(crate) fn slice_spans(
     if width == 0 {
         return Vec::new();
     }
+    let line_width = spans_width(spans);
+    if start_col >= line_width {
+        return Vec::new();
+    }
     let end_col = start_col.saturating_add(width);
     let mut out = Vec::new();
     let mut col = 0usize;

--- a/crates/oyo/src/views/single_pane.rs
+++ b/crates/oyo/src/views/single_pane.rs
@@ -187,6 +187,9 @@ fn build_modified_only_spans(
 pub fn render_single_pane(frame: &mut Frame, app: &mut App, area: Rect) {
     let visible_height = area.height as usize;
     let visible_width = area.width.saturating_sub(GUTTER_WIDTH) as usize;
+    if !app.line_wrap {
+        app.clamp_horizontal_scroll_cached(visible_width);
+    }
 
     // Clone markers to avoid borrow conflicts
     let primary_marker = app.primary_marker.clone();
@@ -681,9 +684,9 @@ pub fn render_single_pane(frame: &mut Frame, app: &mut App, area: Rect) {
         );
         app.clamp_scroll(display_len, visible_height, app.allow_overscroll());
     }
-
     // Clamp horizontal scroll
     app.clamp_horizontal_scroll(max_line_width, visible_width);
+    app.set_current_max_line_width(max_line_width);
 
     // Background style (if set)
     let bg_style = app.theme.background.map(|bg| Style::default().bg(bg));


### PR DESCRIPTION
This pull request refactors how horizontal scrolling and background coloring are handled in the main view rendering functions. The changes introduce a new `slice_spans` utility for precise horizontal slicing of text spans, ensure background colors are correctly padded, and simplify the logic around tab expansion and paragraph scrolling. These updates improve the consistency and correctness of line rendering, especially when horizontal scrolling is active and line wrapping is disabled.

### Rendering improvements for horizontal scrolling and backgrounds

* Introduced the `slice_spans` function in `views/mod.rs` to accurately slice visible portions of a line's spans for horizontal scrolling, and `pad_spans_bg` to pad backgrounds as needed.
* Updated `render_single_pane`, `render_split`, and `render_evolution` to use `slice_spans` and `pad_spans_bg` when line wrapping is off, ensuring only the visible part of each line is rendered and background colors are correctly applied. [[1]](diffhunk://#diff-b078c148a36a12794368199519e6ca9b995c50b8c0a6e2724b9df1b87cd138dcL635-R646) [[2]](diffhunk://#diff-375f5f0a3d6785791aedabf1850e1a72e7fc905cc2938d08ca24a7bd70fdb6aeL333-R340) [[3]](diffhunk://#diff-375f5f0a3d6785791aedabf1850e1a72e7fc905cc2938d08ca24a7bd70fdb6aeL636-R659) [[4]](diffhunk://#diff-7c2d0974bcc4dd98f27217266a4a4fb3864014743d62ba5b898735999e9ea2b7L310-R312)

### Simplification and consistency

* Removed conditional tab expansion based on `line_wrap`, now always expanding tabs for consistency. [[1]](diffhunk://#diff-7c2d0974bcc4dd98f27217266a4a4fb3864014743d62ba5b898735999e9ea2b7L293-L295) [[2]](diffhunk://#diff-b078c148a36a12794368199519e6ca9b995c50b8c0a6e2724b9df1b87cd138dcL618-L620) [[3]](diffhunk://#diff-375f5f0a3d6785791aedabf1850e1a72e7fc905cc2938d08ca24a7bd70fdb6aeL321-L323) [[4]](diffhunk://#diff-375f5f0a3d6785791aedabf1850e1a72e7fc905cc2938d08ca24a7bd70fdb6aeL636-R659)
* Stopped using the `scroll` method on `Paragraph` when line wrapping is off, since horizontal scrolling is now handled via span slicing. [[1]](diffhunk://#diff-7c2d0974bcc4dd98f27217266a4a4fb3864014743d62ba5b898735999e9ea2b7L381-R383) [[2]](diffhunk://#diff-b078c148a36a12794368199519e6ca9b995c50b8c0a6e2724b9df1b87cd138dcL706-R717) [[3]](diffhunk://#diff-375f5f0a3d6785791aedabf1850e1a72e7fc905cc2938d08ca24a7bd70fdb6aeL392-R399) [[4]](diffhunk://#diff-375f5f0a3d6785791aedabf1850e1a72e7fc905cc2938d08ca24a7bd70fdb6aeL710-R724)

### Minor logic adjustments

* Tightened the condition for using diff syntax highlighting in `render_single_pane` to avoid applying it to certain modified or pending lines.

### Dependency updates

* Updated imports in `evolution.rs`, `single_pane.rs`, and `split.rs` to include the new utility functions. [[1]](diffhunk://#diff-7c2d0974bcc4dd98f27217266a4a4fb3864014743d62ba5b898735999e9ea2b7L5-R6) [[2]](diffhunk://#diff-b078c148a36a12794368199519e6ca9b995c50b8c0a6e2724b9df1b87cd138dcL5-R6) [[3]](diffhunk://#diff-375f5f0a3d6785791aedabf1850e1a72e7fc905cc2938d08ca24a7bd70fdb6aeL5-R6)