### PR TITLE
fix: open dashboard selection from filter

### DIFF
--- a/crates/oyo/src/main.rs
+++ b/crates/oyo/src/main.rs
@@ -1283,14 +1283,37 @@ fn run_dashboard<B: Backend>(
                     let list_height = dashboard.list_height(terminal.size()?.height);
                     if dashboard.filter_active() {
                         match key.code {
-                            KeyCode::Esc | KeyCode::Enter => {
+                            KeyCode::Esc => {
                                 dashboard.stop_filter();
+                            }
+                            KeyCode::Enter => {
+                                if let Some(selection) = dashboard.selection() {
+                                    return Ok(Some(selection));
+                                }
                             }
                             KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                                 dashboard.clear_filter();
                             }
                             KeyCode::Backspace => {
                                 dashboard.pop_filter_char();
+                            }
+                            KeyCode::Char('j') | KeyCode::Down => {
+                                dashboard.move_selection(1, list_height);
+                            }
+                            KeyCode::Char('k') | KeyCode::Up => {
+                                dashboard.move_selection(-1, list_height);
+                            }
+                            KeyCode::PageDown => {
+                                dashboard.page_down(list_height);
+                            }
+                            KeyCode::PageUp => {
+                                dashboard.page_up(list_height);
+                            }
+                            KeyCode::Char('g') | KeyCode::Home => {
+                                dashboard.select_first(list_height);
+                            }
+                            KeyCode::Char('G') | KeyCode::End => {
+                                dashboard.select_last(list_height);
                             }
                             KeyCode::Char(ch) => {
                                 dashboard.push_filter_char(ch);


### PR DESCRIPTION
This pull request enhances the dashboard's filter mode navigation and selection experience. It separates the handling of the Enter and Escape keys, and adds support for intuitive keyboard shortcuts to navigate the filtered list.

Improvements to dashboard navigation and selection in filter mode:

* Separated Enter and Escape key handling: Escape now exits filter mode, while Enter selects the current item and returns it.
* Added navigation shortcuts: Users can now use `j`/Down and `k`/Up to move the selection, PageUp/PageDown to scroll by pages, and Home/End or `g`/`G` to jump to the start or end of the list.