### PR TITLE
chore: rename binary to oy

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Step through changes or scroll the full diff, jump between hunks, and watch code
 - **Animated transitions**: Smooth fade in/out animations as changes are applied
 - **Playback**: Automatically step through all changes at a configurable speed
 - **Git integration**: Works as a git external diff tool or standalone
-- **Commit picker**: Browse recent commits and pick ranges interactively (`oyo view`)
+- **Commit picker**: Browse recent commits and pick ranges interactively (`oy view`)
 - **Themes**: Built-in themes plus `.tmTheme` syntax themes (configurable)
 - **Configurable**: XDG config file support for customization
 
@@ -46,77 +46,77 @@ cargo install oyo
 Optional theme override:
 
 ```bash
-oyo --theme-name tokyonight
+oy --theme-name tokyonight
 ```
 
 ### CLI
 
 ```bash
 # Diff uncommitted changes in current git repo
-oyo
+oy
 
 # Compare two files
-oyo old.rs new.rs
+oy old.rs new.rs
 
 # Commit picker
-oyo view
+oy view
 
 # Split view
-oyo old.rs new.rs --view split
+oy old.rs new.rs --view split
 
 # Evolution view
-oyo old.rs new.rs --view evolution
+oy old.rs new.rs --view evolution
 
 # Autoplay mode
-oyo old.rs new.rs --autoplay
+oy old.rs new.rs --autoplay
 
 # Custom autoplay speed (100ms between steps)
-oyo old.rs new.rs --speed 100
+oy old.rs new.rs --speed 100
 
 # No-step mode
-oyo old.rs new.rs --no-step
+oy old.rs new.rs --no-step
 
 # Staged changes (index vs HEAD)
-oyo --staged
+oy --staged
 
 # Git range
-oyo --range HEAD~1..HEAD
+oy --range HEAD~1..HEAD
 # or
-oyo --range main...feature
+oy --range main...feature
 ```
 
 ### Git Integration
 
-`oyo` supports git external diff (7-arg interface) and `git difftool`. For most workflows,
+`oy` supports git external diff (7-arg interface) and `git difftool`. For most workflows,
 `difftool` is smoother; `diff.external` will open a TUI per file.
 
 ```bash
 # One-off (recommended)
-git difftool -y --tool=oyo
+git difftool -y --tool=oy
 ```
 
 Recommended `~/.gitconfig`:
 
 ```gitconfig
-[difftool "oyo"]
-    cmd = oyo "$LOCAL" "$REMOTE"
+[difftool "oy"]
+    cmd = oy "$LOCAL" "$REMOTE"
 
 [difftool]
     prompt = false
 
 [alias]
-    d = difftool -y --tool=oyo
-    oyo = "!oyo"
+    d = difftool -y --tool=oy
+    oy = "!oy"
 ```
 
 External diff setup (optional):
 
 ```bash
-git config --global diff.external oyo
+git config --global diff.external oy
 ```
 
 Note: keep your pager (e.g., `less`, `moar`, `moor`) for normal `git diff` output.
-Do not set `core.pager` to `oyo`. Also avoid `interactive.diffFilter` — it expects
+Do not set `core.pager` to `oy`. Also avoid `interactive.diffFilter` — it expects
 a stdin filter, not a TUI.
 
 ### Jujutsu (jj)
@@ -126,17 +126,17 @@ In `~/.config/jj/config.toml`:
 ```toml
 [ui]
 paginate = "never"
-diff-formatter = ["oyo", "$left", "$right"]
+diff-formatter = ["oy", "$left", "$right"]
 ```
 
-To use `jj diff --tool=oyo`:
+To use `jj diff --tool=oy`:
 
 ```toml
-[diff-tools.oyo]
-command = ["oyo", "$left", "$right"]
+[diff-tools.oy]
+command = ["oy", "$left", "$right"]
 ```
 
-Note: do not set your `ui.pager` to `oyo`.
+Note: do not set your `ui.pager` to `oy`.
 
 Example range diff:
 
@@ -266,5 +266,5 @@ cargo build
 cargo test
 
 # Run CLI in development
-cargo run --bin oyo -- old.rs new.rs
+cargo run --bin oy -- old.rs new.rs
 ```

--- a/crates/oyo/Cargo.toml
+++ b/crates/oyo/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["diff", "tui", "git", "cli", "viewer"]
 categories = ["command-line-utilities", "development-tools"]
 
 [[bin]]
-name = "oyo"
+name = "oy"
 path = "src/main.rs"
 
 [dependencies]

--- a/crates/oyo/src/dashboard.rs
+++ b/crates/oyo/src/dashboard.rs
@@ -1,4 +1,4 @@
-//! Git range picker dashboard for oyo view
+//! Git range picker dashboard for oy view
 
 use crate::config::ResolvedTheme;
 use oyo_core::git::CommitEntry;

--- a/crates/oyo/src/main.rs
+++ b/crates/oyo/src/main.rs
@@ -32,7 +32,7 @@ use std::time::Duration;
 const INDEX_REF: &str = "INDEX";
 
 #[derive(Parser, Debug)]
-#[command(name = "oyo")]
+#[command(name = "oy")]
 #[command(author, version, about = "A step-through diff viewer")]
 #[command(args_conflicts_with_subcommands = true)]
 struct Args {
@@ -40,7 +40,7 @@ struct Args {
     command: Option<Command>,
 
     /// Files or directories to compare: old_file new_file
-    /// Also works as a git external diff tool (git config diff.external oyo)
+    /// Also works as a git external diff tool (git config diff.external oy)
     #[arg(num_args = 0..)]
     paths: Vec<PathBuf>,
 
@@ -151,7 +151,7 @@ enum InputMode {
 }
 
 /// Detect if we're being called as a git external diff tool
-/// Git calls: oyo path old-file old-hex old-mode new-file new-hex new-mode
+/// Git calls: oy path old-file old-hex old-mode new-file new-hex new-mode
 fn detect_input_mode(paths: &[PathBuf]) -> InputMode {
     if paths.len() == 7 {
         // Git external diff format
@@ -313,7 +313,7 @@ fn build_diff_from_input_mode(
                 anyhow::bail!(
                     "Not in a git repository.\n\
                      \n\
-                     Usage: oyo <old_file> <new_file>\n\
+                     Usage: oy <old_file> <new_file>\n\
                      \n\
                      Or run from a git repository to diff uncommitted changes."
                 );
@@ -337,7 +337,7 @@ fn build_diff_from_input_mode(
                 anyhow::bail!(
                     "Not in a git repository.\n\
                      \n\
-                     Usage: oyo --staged\n\
+                     Usage: oy --staged\n\
                      \n\
                      Or run from a git repository."
                 );
@@ -361,7 +361,7 @@ fn build_diff_from_input_mode(
                 anyhow::bail!(
                     "Not in a git repository.\n\
                      \n\
-                     Usage: oyo --range A..B\n\
+                     Usage: oy --range A..B\n\
                      \n\
                      Or run from a git repository."
                 );
@@ -411,7 +411,7 @@ fn build_diff_from_input_mode(
         }
         InputMode::None => {
             anyhow::bail!(
-                "Usage: oyo <old_file> <new_file>\n\
+                "Usage: oy <old_file> <new_file>\n\
                  \n\
                  Or run from a git repository to diff uncommitted changes."
             );

--- a/docs/THEME.md
+++ b/docs/THEME.md
@@ -29,7 +29,7 @@ mode = "light" # or "dark"
 List built-in UI themes:
 
 ```bash
-oyo themes
+oy themes
 ```
 
 ### Built-in UI Themes
@@ -94,7 +94,7 @@ theme = "tokyonight-day"
 ### List syntax themes
 
 ```bash
-oyo syntax-themes
+oy syntax-themes
 ```
 
 This lists:
@@ -128,8 +128,8 @@ If the file can't be loaded, `oyo` falls back to `ansi`.
 ### CLI overrides
 
 ```bash
-oyo --theme-name tokyonight --theme-mode light
-oyo --syntax-theme tokyonight-day
+oy --theme-name tokyonight --theme-mode light
+oy --syntax-theme tokyonight-day
 ```
 
 Note: syntax theme backgrounds are stripped to preserve the UI/diff background.


### PR DESCRIPTION
This PR renames the CLI binary from `oyo` to `oy`.

**Rationale**
`oy` is faster to type and better suited for frequent, muscle-memory usage.

There are no conflicts with Bash builtins, POSIX utilities, or common Unix tools.
The project name remains oyo; this change only affects the executable name.

**Notes**
Documentation and examples have been updated to use oy.

This does not affect functionality or behavior.
Existing installs may need to update aliases/scripts accordingly.