### PR TITLE
Add MultiFileDiff::from_file_pairs for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,9 @@ auto_step_blank_files = true # Auto-step when file would be blank at step 0 (new
 [files]
 panel_visible = true        # Show file panel in multi-file mode
 counts = "active"           # Per-file +/- counts: active, focused, all, off
+
+[no_step]
+auto_jump_on_enter = true   # Jump to first hunk when entering a file in no-step mode
 ```
 
 Example config:

--- a/crates/oyo-core/src/step.rs
+++ b/crates/oyo-core/src/step.rs
@@ -168,6 +168,11 @@ impl DiffNavigator {
         self.state.cursor_change = change_id;
     }
 
+    /// Set cursor change without altering current hunk.
+    pub fn set_cursor_change(&mut self, change_id: Option<usize>) {
+        self.state.cursor_change = change_id;
+    }
+
     /// Clear the non-animated cursor.
     pub fn clear_cursor_change(&mut self) {
         self.state.cursor_change = None;

--- a/crates/oyo/src/config.rs
+++ b/crates/oyo/src/config.rs
@@ -856,6 +856,22 @@ impl Default for FilesConfig {
     }
 }
 
+/// No-step mode configuration
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct NoStepConfig {
+    /// Jump to the first hunk when entering a file in no-step mode
+    pub auto_jump_on_enter: bool,
+}
+
+impl Default for NoStepConfig {
+    fn default() -> Self {
+        Self {
+            auto_jump_on_enter: true,
+        }
+    }
+}
+
 /// File list counts display behavior
 #[derive(Debug, Deserialize, Clone, Copy, Default)]
 #[serde(rename_all = "snake_case")]
@@ -874,6 +890,7 @@ pub struct Config {
     pub ui: UiConfig,
     pub playback: PlaybackConfig,
     pub files: FilesConfig,
+    pub no_step: NoStepConfig,
 }
 
 impl Config {

--- a/crates/oyo/src/main.rs
+++ b/crates/oyo/src/main.rs
@@ -239,6 +239,7 @@ fn apply_config_to_app(app: &mut App, config: &config::Config, args: &Args, ligh
     app.evo_syntax = config.ui.evo.syntax;
     app.auto_step_on_enter = config.playback.auto_step_on_enter;
     app.auto_step_blank_files = config.playback.auto_step_blank_files;
+    app.no_step_auto_jump_on_enter = config.no_step.auto_jump_on_enter;
     app.primary_marker = config.ui.primary_marker.clone();
     app.primary_marker_right = config
         .ui


### PR DESCRIPTION
This pull request introduces a new configuration option for "no-step" mode that allows the application to automatically jump to the first hunk when entering a file, along with several related improvements and refactorings. The changes enhance navigation consistency, add configuration flexibility, and improve test coverage for these behaviors.

**No-step mode enhancements and configuration:**

* Added a new `[no_step]` section to the config (`README.md`, `NoStepConfig` in `config.rs`) allowing users to control whether the app auto-jumps to the first hunk when entering a file in no-step mode (`auto_jump_on_enter`). This is enabled by default. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R272-R274) [[2]](diffhunk://#diff-1da2682ebf482def73775b5d5e3855e9e204772ab59567d68249f08bcc5e4283R859-R874) [[3]](diffhunk://#diff-1da2682ebf482def73775b5d5e3855e9e204772ab59567d68249f08bcc5e4283R893)
* Integrated the new config value into the app state and logic, including a new field `no_step_auto_jump_on_enter` in `App`, initialization in the constructor, and application of the config in `main.rs`. [[1]](diffhunk://#diff-69e78e26e327975c1b8057814d553e5446c0ff9b2deea50d5ae2c2a66d7ccacbR180-R181) [[2]](diffhunk://#diff-69e78e26e327975c1b8057814d553e5446c0ff9b2deea50d5ae2c2a66d7ccacbR378) [[3]](diffhunk://#diff-0ec0e6cffbee945c586b7082a5fa3181550e8a67797f9c6ce8e5f68153a20c27R242)

**Navigation and cursor logic improvements:**

* Refactored logic for setting the cursor when entering a file or restoring state in no-step mode, ensuring the cursor is placed on the first hunk if `auto_jump_on_enter` is enabled and no previous state exists. [[1]](diffhunk://#diff-69e78e26e327975c1b8057814d553e5446c0ff9b2deea50d5ae2c2a66d7ccacbL1645-R1681) [[2]](diffhunk://#diff-69e78e26e327975c1b8057814d553e5446c0ff9b2deea50d5ae2c2a66d7ccacbR2015-R2023) [[3]](diffhunk://#diff-69e78e26e327975c1b8057814d553e5446c0ff9b2deea50d5ae2c2a66d7ccacbL2023) [[4]](diffhunk://#diff-69e78e26e327975c1b8057814d553e5446c0ff9b2deea50d5ae2c2a66d7ccacbR2720-R2726) [[5]](diffhunk://#diff-69e78e26e327975c1b8057814d553e5446c0ff9b2deea50d5ae2c2a66d7ccacbR2856-R2868)
* Added a method to set the cursor directly on a change without altering the hunk, supporting more granular navigation.

**File navigation refactoring:**

* Simplified `next_file` and `prev_file` logic to use a new `select_file` method, improving maintainability and ensuring consistent application of file-enter behaviors. [[1]](diffhunk://#diff-69e78e26e327975c1b8057814d553e5446c0ff9b2deea50d5ae2c2a66d7ccacbL2613-R2629) [[2]](diffhunk://#diff-69e78e26e327975c1b8057814d553e5446c0ff9b2deea50d5ae2c2a66d7ccacbL2648-R2652)

**Multi-file diff utility:**

* Added a `from_file_pairs` constructor to `MultiFileDiff` to simplify test setup and support batch diff creation.

**Testing improvements:**

* Added comprehensive tests to verify cursor restoration and auto-jump behavior in no-step mode, including stability through file navigation cycles. [[1]](diffhunk://#diff-69e78e26e327975c1b8057814d553e5446c0ff9b2deea50d5ae2c2a66d7ccacbL3815-R3828) [[2]](diffhunk://#diff-69e78e26e327975c1b8057814d553e5446c0ff9b2deea50d5ae2c2a66d7ccacbR3862-R3928)