### PR TITLE
Add custom UI themes + syntax variant resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ oyo does **not** replace classic diffs, it adds a new way to review them.
 - **Playback**: Automatically step through all changes at a configurable speed
 - **Git integration**: Works as a git external diff tool or standalone
 - **Commit picker**: Browse recent commits and pick ranges interactively (`oy view`)
-- **Themes**: Built-in themes plus `.tmTheme` syntax themes (configurable)
+- **Themes**: Built-in themes plus `.tmTheme` syntax themes (configurable, with light/dark variants)
 - **Configurable**: XDG config file support for customization
 
 ## Installation
@@ -313,9 +313,8 @@ animation = true
 animation_duration = 150
 autoplay = false
 
-[hunk.wrap]
+[navigation.wrap]
 step = "file"
-hunk = "hunk"
 ```
 
 Config is loaded from (in priority order):

--- a/crates/oyo/src/main.rs
+++ b/crates/oyo/src/main.rs
@@ -473,7 +473,7 @@ fn main() -> Result<()> {
     let args = Args::parse();
     let view_limit = match args.command {
         Some(Command::Themes) => {
-            for name in config::builtin_theme_names() {
+            for name in config::list_ui_themes() {
                 println!("{name}");
             }
             return Ok(());

--- a/docs/THEME.md
+++ b/docs/THEME.md
@@ -62,6 +62,25 @@ oy themes
 
 UI theme tokens are defined in [schema.json](crates/oyo/themes/schema.json).
 
+### Custom UI themes
+
+Place JSON theme files in either:
+
+```
+~/.config/oyo/MyTheme.json
+~/.config/oyo/themes/MyTheme.json
+```
+
+Then reference them by file name (extension optional):
+
+```toml
+[ui.theme]
+name = "MyTheme"
+```
+
+If you provide `MyTheme-light.json` and `MyTheme-dark.json`, `oyo` will pick the
+variant based on `ui.theme.mode` (and fall back to the other if one is missing).
+
 ## Syntax Themes
 
 Syntax highlighting is tmTheme-based. You can select a built-in syntax theme or provide
@@ -84,6 +103,10 @@ When `ui.theme.mode = "light"`, `oyo` tries a light variant first:
 - `rosepine` -> `rosepine-dawn`
 - `catppuccin` -> `catppuccin-latte`
 
+Custom syntax themes can also provide `-light`/`-dark` variants (for example,
+`cyberdream-light.tmTheme` and `cyberdream-dark.tmTheme`). `oyo` will pick the
+appropriate variant based on `ui.theme.mode` and fall back to the other if needed.
+
 You can also pick the variant explicitly:
 
 ```toml
@@ -99,21 +122,23 @@ oy syntax-themes
 
 This lists:
 - embedded syntax themes for built-in UI themes
+- any `.tmTheme` files in `~/.config/oyo`
 - any `.tmTheme` files in `~/.config/oyo/themes`
 
 ### Custom tmTheme
 
-Place a tmTheme file in:
+Place a tmTheme file in either:
 
 ```
+~/.config/oyo/MyTheme.tmTheme
 ~/.config/oyo/themes/MyTheme.tmTheme
 ```
 
-Then reference it by file name:
+Then reference it by name:
 
 ```toml
 [ui.syntax]
-theme = "MyTheme.tmTheme"
+theme = "MyTheme"
 ```
 
 You can also pass a full path:


### PR DESCRIPTION
  - load UI themes from ~/.config/oyo and ~/.config/oyo/themes (with -light/-dark support)
  - list custom UI themes in oy themes
  - allow syntax themes to resolve -light/-dark variants from base name
  - document custom UI themes and syntax variants