### PR TITLE
Add resizable file panel and configurable width

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ auto_step_blank_files = true # Auto-step when file would be blank at step 0 (new
 
 [files]
 panel_visible = true        # Show file panel in multi-file mode
+panel_width = 30            # File panel width (columns)
 counts = "active"           # Per-file +/- counts: active, focused, all, off
 
 [no_step]

--- a/crates/oyo/src/config.rs
+++ b/crates/oyo/src/config.rs
@@ -43,6 +43,7 @@
 //!
 //! [files]
 //! panel_visible = true
+//! panel_width = 30
 //! counts = "active"
 //! ```
 
@@ -1011,6 +1012,8 @@ impl Default for PlaybackConfig {
 pub struct FilesConfig {
     /// Show file panel by default in multi-file mode
     pub panel_visible: bool,
+    /// File panel width (columns)
+    pub panel_width: u16,
     /// When to show per-file +/- counts in the file panel
     pub counts: FileCountMode,
 }
@@ -1019,6 +1022,7 @@ impl Default for FilesConfig {
     fn default() -> Self {
         Self {
             panel_visible: true,
+            panel_width: 30,
             counts: FileCountMode::Active,
         }
     }


### PR DESCRIPTION
This pull request adds support for customizing and interactively resizing the file panel width in the multi-file view of the TUI app. Users can now set a default panel width in the config, adjust it with keyboard shortcuts, or resize it directly with the mouse. The implementation enforces minimum widths for both the file panel and diff view to ensure usability.

**File panel width customization and resizing:**

* Added a new `panel_width` setting to the config (`README.md`, `crates/oyo/src/config.rs`) and initialized it with a default value of 30 columns. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R275) [[2]](diffhunk://#diff-1da2682ebf482def73775b5d5e3855e9e204772ab59567d68249f08bcc5e4283R46) [[3]](diffhunk://#diff-1da2682ebf482def73775b5d5e3855e9e204772ab59567d68249f08bcc5e4283R1015-R1016) [[4]](diffhunk://#diff-1da2682ebf482def73775b5d5e3855e9e204772ab59567d68249f08bcc5e4283R1025)
* Updated the `App` struct and initialization to track `file_panel_width`, its geometry, and resizing state. [[1]](diffhunk://#diff-69e78e26e327975c1b8057814d553e5446c0ff9b2deea50d5ae2c2a66d7ccacbR138-R143) [[2]](diffhunk://#diff-69e78e26e327975c1b8057814d553e5446c0ff9b2deea50d5ae2c2a66d7ccacbR386-R388)
* Applied the configured `panel_width` to the app during startup. [[1]](diffhunk://#diff-0ec0e6cffbee945c586b7082a5fa3181550e8a67797f9c6ce8e5f68153a20c27R222) [[2]](diffhunk://#diff-0ec0e6cffbee945c586b7082a5fa3181550e8a67797f9c6ce8e5f68153a20c27R719)

**Interactive resizing logic:**

* Implemented mouse-driven resizing: users can drag the separator between the file panel and diff view to resize the panel, and the app updates the width accordingly. [[1]](diffhunk://#diff-0ec0e6cffbee945c586b7082a5fa3181550e8a67797f9c6ce8e5f68153a20c27R798-R814) [[2]](diffhunk://#diff-69e78e26e327975c1b8057814d553e5446c0ff9b2deea50d5ae2c2a66d7ccacbR2456-R2502)
* Added keyboard shortcuts (`+`/`-`) to increase or decrease the file panel width when the file list is focused.

**UI rendering and constraints:**

* Enforced minimum widths for both the file panel and diff view, adjusting layout logic to respect these constraints and updating the UI rendering accordingly. [[1]](diffhunk://#diff-69e78e26e327975c1b8057814d553e5446c0ff9b2deea50d5ae2c2a66d7ccacbR67-R69) [[2]](diffhunk://#diff-bc03091be2942ced1861b3008112813bb5fd37c2c77c8e75bb91b9cdfa0fd2c6L3-R3) [[3]](diffhunk://#diff-bc03091be2942ced1861b3008112813bb5fd37c2c77c8e75bb91b9cdfa0fd2c6L542-R542) [[4]](diffhunk://#diff-bc03091be2942ced1861b3008112813bb5fd37c2c77c8e75bb91b9cdfa0fd2c6R560-R570) [[5]](diffhunk://#diff-bc03091be2942ced1861b3008112813bb5fd37c2c77c8e75bb91b9cdfa0fd2c6R589)