### PR TITLE
Restrict syntax theme lookup

### DIFF
--- a/crates/oyo/src/syntax.rs
+++ b/crates/oyo/src/syntax.rs
@@ -476,17 +476,11 @@ fn config_theme_dirs() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
     if let Some(config_path) = Config::config_path() {
         if let Some(parent) = config_path.parent() {
-            let base = parent.to_path_buf();
-            dirs.push(base.clone());
-            dirs.push(base.join("themes"));
+            dirs.push(parent.join("themes"));
         }
     }
     if let Some(config_dir) = dirs::config_dir() {
-        let base = config_dir.join("oyo");
-        if !dirs.contains(&base) {
-            dirs.push(base.clone());
-        }
-        let themes = base.join("themes");
+        let themes = config_dir.join("oyo").join("themes");
         if !dirs.contains(&themes) {
             dirs.push(themes);
         }

--- a/docs/THEME.md
+++ b/docs/THEME.md
@@ -122,15 +122,13 @@ oy syntax-themes
 
 This lists:
 - embedded syntax themes for built-in UI themes
-- any `.tmTheme` files in `~/.config/oyo`
 - any `.tmTheme` files in `~/.config/oyo/themes`
 
 ### Custom tmTheme
 
-Place a tmTheme file in either:
+Place a tmTheme file in:
 
 ```
-~/.config/oyo/MyTheme.tmTheme
 ~/.config/oyo/themes/MyTheme.tmTheme
 ```
 


### PR DESCRIPTION
This pull request updates the logic for discovering theme directories and clarifies the documentation to match the new behavior. The main change is that only the `themes` subdirectory is now considered for custom `.tmTheme` files, both in code and documentation.

**Theme directory discovery:**
- The function `config_theme_dirs` in `crates/oyo/src/syntax.rs` was updated to only include the `themes` subdirectory within the configuration directory, removing support for `.tmTheme` files placed directly in `~/.config/oyo`.

**Documentation update:**
- The documentation in `docs/THEME.md` was revised to remove references to placing `.tmTheme` files directly in `~/.config/oyo`, clarifying that only files in `~/.config/oyo/themes` are supported.