### PR TITLE
Add configurable time formatting and apply across dashboard/blame

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,4 +37,4 @@ dirs = "5.0"
 regex = "1.10"
 unicode-width = "0.1"
 unicode-segmentation = "1.11"
-time = { version = "0.3", features = ["std"] }
+time = { version = "0.3", features = ["std", "formatting", "parsing"] }

--- a/README.md
+++ b/README.md
@@ -248,6 +248,9 @@ hunk = "none"               # "none" | "hunk" | "file"
 # enabled = false           # Show git blame hints (opt-in)
 # mode = "one_shot"         # "one_shot" or "toggle"
 # hunk_hint = true          # Show blame hint when jumping to a hunk
+# [ui.time]
+# mode = "relative"         # "relative" | "absolute" | "custom"
+# format = "[year]-[month]-[day] [hour]:[minute]" # Used when mode = "custom"
 # [ui.split]
 # align_lines = false       # Insert blanks to keep split panes aligned
 # align_fill = "╱"          # Fill character for aligned blanks (empty = no marker)

--- a/crates/oyo-core/src/git.rs
+++ b/crates/oyo-core/src/git.rs
@@ -48,7 +48,7 @@ pub struct CommitEntry {
     pub short_id: String,
     pub parents: Vec<String>,
     pub author: String,
-    pub date: String,
+    pub author_time: Option<i64>,
     pub summary: String,
     pub stats: Option<CommitStats>,
 }
@@ -235,14 +235,13 @@ pub fn get_changes_between_index(
 
 /// Get recent commits with short stats
 pub fn get_recent_commits(repo_path: &Path, limit: usize) -> Result<Vec<CommitEntry>, GitError> {
-    let format = "%H%x1f%h%x1f%P%x1f%an%x1f%ad%x1f%s";
+    let format = "%H%x1f%h%x1f%P%x1f%an%x1f%at%x1f%s";
     let output = Command::new("git")
         .arg("-C")
         .arg(repo_path)
         .arg("log")
         .arg("-n")
         .arg(limit.to_string())
-        .arg("--date=format:%Y-%m-%d %H:%M")
         .arg(format!("--pretty=format:{format}"))
         .arg("--shortstat")
         .output()?;
@@ -271,12 +270,13 @@ pub fn get_recent_commits(repo_path: &Path, limit: usize) -> Result<Vec<CommitEn
             } else {
                 parts[2].split_whitespace().map(|s| s.to_string()).collect()
             };
+            let author_time = parts[4].trim().parse::<i64>().ok();
             commits.push(CommitEntry {
                 id: parts[0].to_string(),
                 short_id: parts[1].to_string(),
                 parents,
                 author: parts[3].to_string(),
-                date: parts[4].to_string(),
+                author_time,
                 summary: parts[5].to_string(),
                 stats: None,
             });

--- a/crates/oyo/src/app.rs
+++ b/crates/oyo/src/app.rs
@@ -10,6 +10,7 @@ use crate::config::{
     FileCountMode, HunkWrapMode, ModifiedStepMode, ResolvedTheme, StepWrapMode, SyntaxMode,
 };
 use crate::syntax::{SyntaxCache, SyntaxEngine, SyntaxSide};
+use crate::time_format::TimeFormatter;
 use oyo_core::{
     multi::BlameSource, AnimationFrame, Change, ChangeKind, LineKind, MultiFileDiff, StepDirection,
     StepState, ViewLine,
@@ -327,6 +328,8 @@ pub struct App {
     pub clear_active_on_next_render: bool,
     /// Resolved theme (colors, gradients)
     pub theme: ResolvedTheme,
+    /// Time formatting rules
+    pub time_format: TimeFormatter,
     /// Whether the UI theme is in light mode
     pub theme_is_light: bool,
     /// Whether stepping is enabled (false = no-step diff view)
@@ -565,6 +568,7 @@ impl App {
             extent_marker_right: "▐".to_string(),
             clear_active_on_next_render: false,
             theme: ResolvedTheme::default(),
+            time_format: TimeFormatter::default(),
             theme_is_light: false,
             stepping: true,
             hunk_wrap: HunkWrapMode::None,
@@ -1780,12 +1784,14 @@ impl App {
 
     pub(crate) fn format_blame_github_info(&mut self, info: &BlameInfo, now: i64) -> String {
         self.ensure_blame_user_name();
-        format_blame_github_text(info, self.blame_user_name.as_deref(), now)
+        let time_text = self.time_format.format(info.author_time, now);
+        format_blame_github_text(info, self.blame_user_name.as_deref(), &time_text)
     }
 
     fn format_blame_hint_info(&mut self, info: &BlameInfo, now: i64) -> String {
         self.ensure_blame_user_name();
-        format_blame_hint_text(info, self.blame_user_name.as_deref(), now, 60)
+        let time_text = self.time_format.format(info.author_time, now);
+        format_blame_hint_text(info, self.blame_user_name.as_deref(), &time_text, 60)
     }
 
     fn ensure_blame_worker(&mut self) {

--- a/crates/oyo/src/blame.rs
+++ b/crates/oyo/src/blame.rs
@@ -147,7 +147,11 @@ pub fn blame_range(
     Some(entries)
 }
 
-pub fn format_blame_github_text(info: &BlameInfo, git_user: Option<&str>, now: i64) -> String {
+pub fn format_blame_github_text(
+    info: &BlameInfo,
+    git_user: Option<&str>,
+    time_text: &str,
+) -> String {
     if info.uncommitted {
         return "Uncommitted".to_string();
     }
@@ -157,10 +161,7 @@ pub fn format_blame_github_text(info: &BlameInfo, git_user: Option<&str>, now: i
             author = "You".to_string();
         }
     }
-    let relative = info
-        .author_time
-        .map(|ts| format_relative_age(ts, now))
-        .unwrap_or_else(|| "Unknown".to_string());
+    let relative = time_text;
     let short = short_commit(&info.commit);
     if info.summary.is_empty() {
         format!("{author}, {relative} {short}")
@@ -172,7 +173,7 @@ pub fn format_blame_github_text(info: &BlameInfo, git_user: Option<&str>, now: i
 pub fn format_blame_hint_text(
     info: &BlameInfo,
     git_user: Option<&str>,
-    now: i64,
+    time_text: &str,
     max_summary_len: usize,
 ) -> String {
     if info.uncommitted {
@@ -184,10 +185,7 @@ pub fn format_blame_hint_text(
             author = "You".to_string();
         }
     }
-    let relative = info
-        .author_time
-        .map(|ts| format_relative_age(ts, now))
-        .unwrap_or_else(|| "Unknown".to_string());
+    let relative = time_text;
     let short = short_commit(&info.commit);
     if info.summary.is_empty() {
         return format!("{author}, {relative} {short}");
@@ -209,32 +207,5 @@ fn short_commit(commit: &str) -> String {
         commit[..8].to_string()
     } else {
         commit.to_string()
-    }
-}
-
-fn format_relative_age(epoch: i64, now: i64) -> String {
-    let age_secs = now.saturating_sub(epoch);
-    let age_days = age_secs / 86_400;
-    if age_days <= 0 {
-        return "today".to_string();
-    }
-    if age_days == 1 {
-        return "1 day ago".to_string();
-    }
-    if age_days < 30 {
-        return format!("{age_days} days ago");
-    }
-    if age_days < 365 {
-        let months = (age_days / 30).max(1);
-        if months == 1 {
-            return "1 month ago".to_string();
-        }
-        return format!("{months} months ago");
-    }
-    let years = age_days / 365;
-    if years == 1 {
-        "1 year ago".to_string()
-    } else {
-        format!("{years} years ago")
     }
 }

--- a/crates/oyo/src/config.rs
+++ b/crates/oyo/src/config.rs
@@ -690,6 +690,8 @@ pub struct UiConfig {
     pub diff: DiffConfig,
     /// Blame display settings
     pub blame: BlameConfig,
+    /// Time display settings
+    pub time: TimeConfig,
     /// Enable stepping (default: true). If false, shows all changes (no-step behavior)
     pub stepping: bool,
     /// Marker for primary active line (left pane / unified pane)
@@ -721,6 +723,7 @@ impl Default for UiConfig {
             evo: EvoViewConfig::default(),
             diff: DiffConfig::default(),
             blame: BlameConfig::default(),
+            time: TimeConfig::default(),
             stepping: true,
             primary_marker: "▶".to_string(),
             primary_marker_right: None,
@@ -952,6 +955,59 @@ impl Default for BlameConfig {
             enabled: false,
             mode: BlameMode::OneShot,
             hunk_hint: true,
+        }
+    }
+}
+
+/// Time display mode
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum TimeMode {
+    #[default]
+    Relative,
+    Absolute,
+    Custom,
+}
+
+/// Time display configuration
+#[derive(Debug, Clone, Deserialize)]
+#[serde(from = "TimeConfigDef")]
+pub struct TimeConfig {
+    pub mode: TimeMode,
+    pub format: String,
+}
+
+impl Default for TimeConfig {
+    fn default() -> Self {
+        Self {
+            mode: TimeMode::Relative,
+            format: String::new(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum TimeConfigDef {
+    Mode(TimeMode),
+    Detailed {
+        #[serde(default)]
+        mode: TimeMode,
+        format: Option<String>,
+    },
+}
+
+impl From<TimeConfigDef> for TimeConfig {
+    fn from(def: TimeConfigDef) -> Self {
+        match def {
+            TimeConfigDef::Mode(mode) => Self {
+                mode,
+                ..Self::default()
+            },
+            TimeConfigDef::Detailed { mode, format } => Self {
+                mode,
+                format: format.unwrap_or_default(),
+            },
         }
     }
 }

--- a/crates/oyo/src/main.rs
+++ b/crates/oyo/src/main.rs
@@ -6,11 +6,13 @@ mod color;
 mod config;
 mod dashboard;
 mod syntax;
+mod time_format;
 mod ui;
 mod views;
 
 use crate::dashboard::{Dashboard, DashboardConfig, DashboardSelection};
 use crate::syntax::{list_syntax_themes, SyntaxEngine};
+use crate::time_format::TimeFormatter;
 use anyhow::{Context, Result};
 use app::{App, ViewMode};
 use clap::{Parser, Subcommand};
@@ -264,6 +266,7 @@ fn apply_config_to_app(app: &mut App, config: &config::Config, args: &Args, ligh
         .clone()
         .unwrap_or_else(|| "▐".to_string());
     app.theme = config.ui.theme.resolve(light_mode);
+    app.time_format = TimeFormatter::new(&config.ui.time);
     app.theme_is_light = light_mode;
 
     if args.no_step {
@@ -566,6 +569,7 @@ fn main() -> Result<()> {
             .context("Failed to get staged changes")?;
 
         let theme = config.ui.theme.resolve(light_mode);
+        let time_format = TimeFormatter::new(&config.ui.time);
         let mut dashboard = Dashboard::new(DashboardConfig {
             repo_root: repo_root.clone(),
             branch: branch.clone(),
@@ -575,6 +579,7 @@ fn main() -> Result<()> {
             theme,
             primary_marker: config.ui.primary_marker.clone(),
             extent_marker: config.ui.extent_marker.clone(),
+            time_format,
         });
 
         let mut terminal = setup_terminal()?;

--- a/crates/oyo/src/time_format.rs
+++ b/crates/oyo/src/time_format.rs
@@ -1,0 +1,94 @@
+use crate::config::{TimeConfig, TimeMode};
+use time::format_description::{parse_owned, parse_strftime_owned, OwnedFormatItem};
+use time::OffsetDateTime;
+
+const DEFAULT_ABSOLUTE_FORMAT: &str = "[year]-[month]-[day] [hour]:[minute]";
+
+#[derive(Debug, Clone)]
+pub struct TimeFormatter {
+    mode: TimeMode,
+    absolute_format: OwnedFormatItem,
+    custom_format: Option<OwnedFormatItem>,
+}
+
+impl Default for TimeFormatter {
+    fn default() -> Self {
+        Self::new(&TimeConfig::default())
+    }
+}
+
+impl TimeFormatter {
+    pub fn new(config: &TimeConfig) -> Self {
+        let absolute_format = parse_owned::<2>(DEFAULT_ABSOLUTE_FORMAT)
+            .or_else(|_| parse_strftime_owned("%Y-%m-%d %H:%M"))
+            .expect("default time format should parse");
+        let custom_format = match config.mode {
+            TimeMode::Custom => parse_format(&config.format),
+            _ => None,
+        };
+        Self {
+            mode: config.mode,
+            absolute_format,
+            custom_format,
+        }
+    }
+
+    pub fn format(&self, epoch: Option<i64>, now: i64) -> String {
+        let Some(epoch) = epoch else {
+            return "Unknown".to_string();
+        };
+        match self.mode {
+            TimeMode::Relative => format_relative_age(epoch, now),
+            TimeMode::Absolute => format_absolute(epoch, &self.absolute_format)
+                .unwrap_or_else(|| "Unknown".to_string()),
+            TimeMode::Custom => {
+                let format = self.custom_format.as_ref().unwrap_or(&self.absolute_format);
+                format_absolute(epoch, format).unwrap_or_else(|| "Unknown".to_string())
+            }
+        }
+    }
+}
+
+fn parse_format(format: &str) -> Option<OwnedFormatItem> {
+    let trimmed = format.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.contains('%') {
+        parse_strftime_owned(trimmed).ok()
+    } else {
+        parse_owned::<2>(trimmed).ok()
+    }
+}
+
+fn format_absolute(epoch: i64, format: &OwnedFormatItem) -> Option<String> {
+    let date_time = OffsetDateTime::from_unix_timestamp(epoch).ok()?;
+    date_time.format(format).ok()
+}
+
+pub fn format_relative_age(epoch: i64, now: i64) -> String {
+    let age_secs = now.saturating_sub(epoch);
+    let age_days = age_secs / 86_400;
+    if age_days <= 0 {
+        return "today".to_string();
+    }
+    if age_days == 1 {
+        return "1 day ago".to_string();
+    }
+    if age_days < 30 {
+        return format!("{age_days} days ago");
+    }
+    if age_days < 365 {
+        let months = (age_days / 30).max(1);
+        if months == 1 {
+            return "1 month ago".to_string();
+        }
+        return format!("{months} months ago");
+    }
+    let years = age_days / 365;
+    if years == 1 {
+        "1 year ago".to_string()
+    } else {
+        format!("{years} years ago")
+    }
+}


### PR DESCRIPTION
This pull request introduces a new, configurable time formatting system for commit and blame information throughout the application. The changes allow users to choose between relative, absolute, or custom date formats for commit times, and update the relevant data structures, configuration, and UI rendering logic to support this flexibility.

The most important changes are:

**Time formatting infrastructure:**

* Added a new `TimeFormatter` utility and integrated it into the `App` and `Dashboard` components, replacing previous ad-hoc time formatting logic. (`crates/oyo/src/app.rs`, `crates/oyo/src/dashboard.rs`, `crates/oyo/src/main.rs`, `crates/oyo/src/blame.rs`, `crates/oyo/src/time_format.rs`) [[1]](diffhunk://#diff-69e78e26e327975c1b8057814d553e5446c0ff9b2deea50d5ae2c2a66d7ccacbR13) [[2]](diffhunk://#diff-69e78e26e327975c1b8057814d553e5446c0ff9b2deea50d5ae2c2a66d7ccacbR331-R332) [[3]](diffhunk://#diff-69e78e26e327975c1b8057814d553e5446c0ff9b2deea50d5ae2c2a66d7ccacbR571) [[4]](diffhunk://#diff-d20a3ecc97cdd7f4b7a3cae30abf4c10ebea6b881c62116944b6dae20d2767e6R4) [[5]](diffhunk://#diff-d20a3ecc97cdd7f4b7a3cae30abf4c10ebea6b881c62116944b6dae20d2767e6R14) [[6]](diffhunk://#diff-d20a3ecc97cdd7f4b7a3cae30abf4c10ebea6b881c62116944b6dae20d2767e6R71) [[7]](diffhunk://#diff-d20a3ecc97cdd7f4b7a3cae30abf4c10ebea6b881c62116944b6dae20d2767e6R84) [[8]](diffhunk://#diff-d20a3ecc97cdd7f4b7a3cae30abf4c10ebea6b881c62116944b6dae20d2767e6L90-R111) [[9]](diffhunk://#diff-d20a3ecc97cdd7f4b7a3cae30abf4c10ebea6b881c62116944b6dae20d2767e6R143) [[10]](diffhunk://#diff-d20a3ecc97cdd7f4b7a3cae30abf4c10ebea6b881c62116944b6dae20d2767e6R603) [[11]](diffhunk://#diff-d20a3ecc97cdd7f4b7a3cae30abf4c10ebea6b881c62116944b6dae20d2767e6R629-R630) [[12]](diffhunk://#diff-d20a3ecc97cdd7f4b7a3cae30abf4c10ebea6b881c62116944b6dae20d2767e6L675-R694) [[13]](diffhunk://#diff-d20a3ecc97cdd7f4b7a3cae30abf4c10ebea6b881c62116944b6dae20d2767e6L705-R727) [[14]](diffhunk://#diff-d20a3ecc97cdd7f4b7a3cae30abf4c10ebea6b881c62116944b6dae20d2767e6L733-R756) [[15]](diffhunk://#diff-0ec0e6cffbee945c586b7082a5fa3181550e8a67797f9c6ce8e5f68153a20c27R9-R15) [[16]](diffhunk://#diff-0ec0e6cffbee945c586b7082a5fa3181550e8a67797f9c6ce8e5f68153a20c27R269) [[17]](diffhunk://#diff-0ec0e6cffbee945c586b7082a5fa3181550e8a67797f9c6ce8e5f68153a20c27R572)

* Updated the `CommitEntry` struct and related Git logic to store commit times as `Option<i64>` (epoch timestamp), enabling flexible formatting downstream. (`crates/oyo-core/src/git.rs`) [[1]](diffhunk://#diff-3dd40592daca4600ed6656c09108f47ddcc83cfe1c913acc124d2b325ae98848L51-R51) [[2]](diffhunk://#diff-3dd40592daca4600ed6656c09108f47ddcc83cfe1c913acc124d2b325ae98848L238-L245) [[3]](diffhunk://#diff-3dd40592daca4600ed6656c09108f47ddcc83cfe1c913acc124d2b325ae98848R273-R279)

**Configuration enhancements:**

* Added a `[ui.time]` section to the configuration, with support for `mode` (`relative`, `absolute`, or `custom`) and a custom `format` string. Provided appropriate defaults and parsing logic. (`README.md`, `crates/oyo/src/config.rs`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R251-R253) [[2]](diffhunk://#diff-1da2682ebf482def73775b5d5e3855e9e204772ab59567d68249f08bcc5e4283R693-R694) [[3]](diffhunk://#diff-1da2682ebf482def73775b5d5e3855e9e204772ab59567d68249f08bcc5e4283R726) [[4]](diffhunk://#diff-1da2682ebf482def73775b5d5e3855e9e204772ab59567d68249f08bcc5e4283R962-R1014)

**UI and blame formatting changes:**

* Updated blame and dashboard displays to use the new time formatting, removing the old `format_relative_age` function and adapting formatting functions to accept pre-formatted time strings. (`crates/oyo/src/blame.rs`, `crates/oyo/src/app.rs`, `crates/oyo/src/dashboard.rs`) [[1]](diffhunk://#diff-dc78f4af1b6bb399b40ed67c36296f659251edc3184808a5ac4695f477c90bdeL150-R154) [[2]](diffhunk://#diff-dc78f4af1b6bb399b40ed67c36296f659251edc3184808a5ac4695f477c90bdeL160-R164) [[3]](diffhunk://#diff-dc78f4af1b6bb399b40ed67c36296f659251edc3184808a5ac4695f477c90bdeL175-R176) [[4]](diffhunk://#diff-dc78f4af1b6bb399b40ed67c36296f659251edc3184808a5ac4695f477c90bdeL187-R188) [[5]](diffhunk://#diff-dc78f4af1b6bb399b40ed67c36296f659251edc3184808a5ac4695f477c90bdeL214-L240) [[6]](diffhunk://#diff-69e78e26e327975c1b8057814d553e5446c0ff9b2deea50d5ae2c2a66d7ccacbL1783-R1794) [[7]](diffhunk://#diff-d20a3ecc97cdd7f4b7a3cae30abf4c10ebea6b881c62116944b6dae20d2767e6L57-R59) [[8]](diffhunk://#diff-d20a3ecc97cdd7f4b7a3cae30abf4c10ebea6b881c62116944b6dae20d2767e6L90-R111) [[9]](diffhunk://#diff-d20a3ecc97cdd7f4b7a3cae30abf4c10ebea6b881c62116944b6dae20d2767e6L675-R694) [[10]](diffhunk://#diff-d20a3ecc97cdd7f4b7a3cae30abf4c10ebea6b881c62116944b6dae20d2767e6L705-R727) [[11]](diffhunk://#diff-d20a3ecc97cdd7f4b7a3cae30abf4c10ebea6b881c62116944b6dae20d2767e6L733-R756)

**Dependency updates:**

* Enabled the `formatting` and `parsing` features for the `time` crate to support custom time formatting. (`Cargo.toml`)…hboard/blame"