### PR TITLE
Context folding

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ oyo does **not** replace classic diffs, it adds a new way to review them.
 - **Blame hints**: One-shot or toggle blame previews while stepping (opt-in)
 - **Command palette**: Search for commands and files without leaving the diff
 - **Line wrap**: Toggle wrapping for long lines
+- **Context folding**: Collapse long unchanged blocks on demand
 - **Animated transitions**: Smooth fade in/out animations as changes are applied
 - **Playback**: Automatically step through all changes at a configurable speed
 - **Git integration**: Works as a git external diff tool or standalone
@@ -211,6 +212,7 @@ command = ["oy", "$left", "$right"]
 | `Z` | Toggle zen mode |
 | `a` | Toggle animations |
 | `w` | Toggle line wrap |
+| `v` | Toggle context folding |
 | `t` | Toggle syntax highlight |
 | `E` | Toggle evo syntax (context/full) |
 | `s` | Toggle stepping (no-step mode) |
@@ -239,6 +241,7 @@ auto_center = true          # Auto-center on active change (default: true)
 topbar = true               # Show top bar in diff view (default: true)
 view_mode = "unified"       # Default: "unified", "split", "evolution", or "blame"
 line_wrap = false           # Wrap long lines (default: false, uses horizontal scroll)
+fold_context = "off"        # "off", "on", or "counts"
 scrollbar = false           # Show scrollbar (default: false)
 strikethrough_deletions = false # Show strikethrough on deleted text
 gutter_signs = true         # Show +/- sign column (unified/evolution)

--- a/crates/oyo/src/app/blame.rs
+++ b/crates/oyo/src/app/blame.rs
@@ -39,10 +39,7 @@ impl App {
 
     fn active_view_line(&mut self) -> Option<ViewLine> {
         let frame = oyo_core::AnimationFrame::Idle;
-        let view_lines = self
-            .multi_diff
-            .current_navigator()
-            .current_view_with_frame(frame);
+        let view_lines = self.current_view_with_frame(frame);
         let mut fallback: Option<ViewLine> = None;
         for line in view_lines {
             if line.is_primary_active {
@@ -208,7 +205,7 @@ impl App {
     }
 
     fn blame_text_for_line(&mut self, view_line: &ViewLine) -> Option<String> {
-        if !self.blame_enabled || !self.stepping {
+        if !self.blame_enabled {
             return None;
         }
         if self.should_force_uncommitted_blame(view_line) {
@@ -631,7 +628,7 @@ impl App {
     }
 
     pub fn trigger_blame_hint(&mut self) {
-        if !self.blame_enabled || !self.stepping {
+        if !self.blame_enabled {
             return;
         }
         self.clear_blame_hunk_hint();

--- a/crates/oyo/src/app/files.rs
+++ b/crates/oyo/src/app/files.rs
@@ -333,10 +333,7 @@ impl App {
     #[allow(dead_code)]
     pub fn total_lines(&mut self) -> usize {
         let frame = self.animation_frame();
-        self.multi_diff
-            .current_navigator()
-            .current_view_with_frame(frame)
-            .len()
+        self.current_view_with_frame(frame).len()
     }
 
     /// Get statistics about the current file's diff

--- a/crates/oyo/src/app/palette.rs
+++ b/crates/oyo/src/app/palette.rs
@@ -6,6 +6,7 @@ pub(crate) enum PaletteAction {
     ToggleViewMode,
     SetViewMode(ViewMode),
     ToggleLineWrap,
+    ToggleFoldContext,
     ToggleSyntax,
     ToggleHelp,
     ToggleZen,
@@ -175,6 +176,10 @@ impl App {
                 action: PaletteAction::ToggleLineWrap,
             },
             PaletteEntry {
+                label: "Toggle context folding".to_string(),
+                action: PaletteAction::ToggleFoldContext,
+            },
+            PaletteEntry {
                 label: "Toggle syntax highlight".to_string(),
                 action: PaletteAction::ToggleSyntax,
             },
@@ -234,6 +239,7 @@ impl App {
             PaletteAction::ToggleViewMode => self.toggle_view_mode(),
             PaletteAction::SetViewMode(mode) => self.set_view_mode(mode),
             PaletteAction::ToggleLineWrap => self.toggle_line_wrap(),
+            PaletteAction::ToggleFoldContext => self.toggle_fold_context(),
             PaletteAction::ToggleSyntax => self.toggle_syntax(),
             PaletteAction::ToggleHelp => self.toggle_help(),
             PaletteAction::ToggleZen => self.toggle_zen(),

--- a/crates/oyo/src/app/search.rs
+++ b/crates/oyo/src/app/search.rs
@@ -240,10 +240,7 @@ impl App {
             None => return Vec::new(),
         };
         let frame = self.animation_frame();
-        let view = self
-            .multi_diff
-            .current_navigator()
-            .current_view_with_frame(frame);
+        let view = self.current_view_with_frame(frame);
         let mut matches = Vec::new();
 
         match self.view_mode {

--- a/crates/oyo/src/blame.rs
+++ b/crates/oyo/src/blame.rs
@@ -199,7 +199,7 @@ fn truncate_with_ellipsis(text: &str, max_len: usize) -> String {
         return text.to_string();
     }
     let suffix_len = max_len.saturating_sub(3);
-    format!("{}...", &text[..suffix_len])
+    format!("{}…", &text[..suffix_len])
 }
 
 fn short_commit(commit: &str) -> String {

--- a/crates/oyo/src/config.rs
+++ b/crates/oyo/src/config.rs
@@ -672,6 +672,8 @@ pub struct UiConfig {
     pub view_mode: Option<String>,
     /// Enable line wrapping (default: false, uses horizontal scroll instead)
     pub line_wrap: bool,
+    /// Collapse long unchanged (context) blocks ("off", "on", or "counts")
+    pub fold_context: FoldContextMode,
     /// Show scrollbar (default: false)
     pub scrollbar: bool,
     /// Show strikethrough on deleted text
@@ -714,6 +716,7 @@ impl Default for UiConfig {
             auto_center: true,
             view_mode: None,
             line_wrap: false,
+            fold_context: FoldContextMode::Off,
             scrollbar: false,
             strikethrough_deletions: false,
             gutter_signs: true,
@@ -871,6 +874,29 @@ fn diff_extent_marker_default() -> DiffExtentMarkerMode {
 
 fn diff_extent_marker_scope_default() -> DiffExtentMarkerScope {
     DiffExtentMarkerScope::Progress
+}
+
+/// Context folding display mode
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum FoldContextMode {
+    /// No folding
+    #[default]
+    Off,
+    /// Fold with a minimal marker
+    On,
+    /// Fold with a line count marker
+    Counts,
+}
+
+impl FoldContextMode {
+    pub fn is_enabled(self) -> bool {
+        !matches!(self, FoldContextMode::Off)
+    }
+
+    pub fn show_counts(self) -> bool {
+        matches!(self, FoldContextMode::Counts)
+    }
 }
 /// Evolution view syntax scope
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]

--- a/crates/oyo/src/dashboard.rs
+++ b/crates/oyo/src/dashboard.rs
@@ -828,7 +828,7 @@ fn truncate_text(text: &str, max_width: usize) -> String {
         acc.push(ch);
         width += ch_width;
     }
-    format!("{acc}...")
+    format!("{acc}…")
 }
 
 fn shorten_hash(hash: &str) -> String {

--- a/crates/oyo/src/ui.rs
+++ b/crates/oyo/src/ui.rs
@@ -34,7 +34,7 @@ fn truncate_filename_keep_ext(name: &str, max_width: usize) -> String {
     let ext_len = ext.len();
     if ext_len >= max_width {
         let suffix_len = max_width.saturating_sub(3);
-        return format!("...{}", &name[name.len().saturating_sub(suffix_len)..]);
+        return format!("…{}", &name[name.len().saturating_sub(suffix_len)..]);
     }
 
     if ext_len == 0 {
@@ -47,7 +47,7 @@ fn truncate_filename_keep_ext(name: &str, max_width: usize) -> String {
         } else {
             ""
         };
-        return format!("{head}...{tail}");
+        return format!("{head}…{tail}");
     }
 
     let max_stem_len = max_width.saturating_sub(ext_len);
@@ -65,7 +65,7 @@ fn truncate_filename_keep_ext(name: &str, max_width: usize) -> String {
     } else {
         ""
     };
-    format!("{head}...{tail}{ext}")
+    format!("{head}…{tail}{ext}")
 }
 
 fn text_width(text: &str) -> usize {
@@ -155,7 +155,7 @@ fn pad_spans_right(spans: Vec<Span>, width: usize) -> Vec<Span> {
     out
 }
 
-/// Truncate a path to fit a given width, using /.../ for middle sections
+/// Truncate a path to fit a given width, using /…/ for middle sections
 fn truncate_path(path: &str, max_width: usize) -> String {
     if max_width == 0 {
         return String::new();
@@ -176,8 +176,8 @@ fn truncate_path(path: &str, max_width: usize) -> String {
     let first = parts[0];
     let last = parts.last().unwrap_or(&"");
 
-    // If just first + last fits with /.../, use that
-    let prefix = format!("{}/.../", first);
+    // If just first + last fits with /…/, use that
+    let prefix = format!("{}/…/", first);
     let available = max_width.saturating_sub(prefix.len());
     if available > 0 {
         let last_display = truncate_filename_keep_ext(last, available);
@@ -187,11 +187,11 @@ fn truncate_path(path: &str, max_width: usize) -> String {
         }
     }
 
-    // Otherwise just show .../filename
+    // Otherwise just show …/filename
     if max_width <= 4 {
         return ".".repeat(max_width);
     }
-    let prefix = ".../";
+    let prefix = "…/";
     let available = max_width.saturating_sub(prefix.len());
     if available == 0 {
         return ".".repeat(max_width);
@@ -220,7 +220,7 @@ fn truncate_text(text: &str, max_width: usize) -> String {
         acc.push(ch);
         width += ch_width;
     }
-    format!("{acc}...")
+    format!("{acc}…")
 }
 
 /// Main drawing function
@@ -1253,6 +1253,7 @@ fn draw_help_popover(frame: &mut Frame, app: &mut App) {
     push_help_line(&mut lines, "^G", "Show full file path");
     push_help_line(&mut lines, "z", "Center on active");
     push_help_line(&mut lines, "w", "Toggle line wrap");
+    push_help_line(&mut lines, "v", "Toggle context folding");
     push_help_line(&mut lines, "t", "Toggle syntax highlight");
     if app.view_mode == ViewMode::Evolution {
         push_help_line(&mut lines, "E", "Toggle evo syntax (context/full)");
@@ -1440,7 +1441,7 @@ fn draw_command_palette_popover(frame: &mut Frame, app: &mut App) {
         .split(content);
 
     let query = app.command_palette_query();
-    let placeholder = "Search for commands...";
+    let placeholder = "Search for commands…";
     let (query_text, query_style) = if query.is_empty() {
         (placeholder, Style::default().fg(app.theme.text_muted))
     } else {
@@ -1550,7 +1551,7 @@ fn draw_file_search_popover(frame: &mut Frame, app: &mut App) {
         .split(content);
 
     let query = app.file_search_query();
-    let placeholder = "Search for files...";
+    let placeholder = "Search for files…";
     let (query_text, query_style) = if query.is_empty() {
         (placeholder, Style::default().fg(app.theme.text_muted))
     } else {

--- a/crates/oyo/src/views/blame.rs
+++ b/crates/oyo/src/views/blame.rs
@@ -46,10 +46,7 @@ pub fn render_blame(frame: &mut Frame, app: &mut App, area: Rect) {
     app.multi_diff
         .current_navigator()
         .set_show_hunk_extent_while_stepping(show_extent);
-    let view_lines = app
-        .multi_diff
-        .current_navigator()
-        .current_view_with_frame(animation_frame);
+    let view_lines = app.current_view_with_frame(animation_frame);
 
     let now = OffsetDateTime::now_utc().unix_timestamp();
     let time_bucket = now / 60;

--- a/crates/oyo/src/views/mod.rs
+++ b/crates/oyo/src/views/mod.rs
@@ -73,7 +73,7 @@ pub(crate) fn boost_inline_bg(app: &App, base_bg: Option<Color>, accent: Color) 
 }
 
 pub(crate) fn pending_tail_text(count: usize) -> String {
-    format!("... +{} more", count)
+    format!("+{} More", count)
 }
 
 pub(crate) fn diff_line_bg(kind: LineKind, theme: &ResolvedTheme) -> Option<Color> {
@@ -521,7 +521,7 @@ pub(crate) fn truncate_text(text: &str, max_width: usize) -> String {
         return text.to_string();
     }
     let suffix_len = max_width.saturating_sub(3);
-    format!("{}...", &text[..suffix_len])
+    format!("{}…", &text[..suffix_len])
 }
 
 use crate::app::{AnimationPhase, App};

--- a/crates/oyo/src/views/tests.rs
+++ b/crates/oyo/src/views/tests.rs
@@ -160,7 +160,7 @@ fn test_unified_wrap_hunk_hint_overflow_places_above() {
     let lines = buffer_text(&render_buffer(&mut app, 20, 4));
     let hint_idx = lines
         .iter()
-        .position(|line| line.contains("last step"))
+        .position(|line| line.contains("Last step"))
         .expect("virtual hint should render");
     let long_idx = lines
         .iter()
@@ -196,7 +196,7 @@ fn test_split_wrap_hunk_hint_overflow_places_above() {
     let lines = buffer_text(&render_buffer(&mut app, 60, 4));
     let hint_idx = lines
         .iter()
-        .position(|line| line.contains("last step"))
+        .position(|line| line.contains("Last step"))
         .expect("virtual hint should render");
     let long_idx = lines
         .iter()

--- a/crates/oyo/src/views/unified_pane.rs
+++ b/crates/oyo/src/views/unified_pane.rs
@@ -5,7 +5,7 @@ use super::{
     pad_spans_bg, pending_tail_text, render_empty_state, slice_spans, spans_to_text, spans_width,
     truncate_text, wrap_count_for_spans, wrap_count_for_text, TAB_WIDTH,
 };
-use crate::app::{AnimationPhase, App};
+use crate::app::{is_fold_line, AnimationPhase, App};
 use crate::color;
 use crate::config::{DiffForegroundMode, DiffHighlightMode, ModifiedStepMode};
 use crate::syntax::SyntaxSide;
@@ -247,10 +247,7 @@ pub fn render_unified_pane(frame: &mut Frame, app: &mut App, area: Rect) {
     app.multi_diff
         .current_navigator()
         .set_show_hunk_extent_while_stepping(show_extent);
-    let view_lines = app
-        .multi_diff
-        .current_navigator()
-        .current_view_with_frame(animation_frame);
+    let view_lines = app.current_view_with_frame(animation_frame);
     let blame_extra_rows = if matches!(app.view_mode, crate::app::ViewMode::Blame) {
         app.blame_extra_rows.clone()
     } else {
@@ -327,13 +324,6 @@ pub fn render_unified_pane(frame: &mut Frame, app: &mut App, area: Rect) {
         parts.push((hint.to_string(), false));
     }
     let virtual_text = if show_virtual && !parts.is_empty() {
-        if pending_insert_only == 0 {
-            if let Some((first, allow_prefix)) = parts.first_mut() {
-                if *allow_prefix {
-                    *first = format!("... {first}");
-                }
-            }
-        }
         Some(
             parts
                 .into_iter()
@@ -480,8 +470,13 @@ pub fn render_unified_pane(frame: &mut Frame, app: &mut App, area: Rect) {
             }
         }
 
+        let fold_line = is_fold_line(view_line);
         let line_num = view_line.old_line.or(view_line.new_line).unwrap_or(0);
-        let line_num_str = format!("{:4}", line_num);
+        let line_num_str = if fold_line || line_num == 0 {
+            "    ".to_string()
+        } else {
+            format!("{:4}", line_num)
+        };
 
         // Line number color from theme - use gradient base for diff types
         let insert_base = color::gradient_color(&app.theme.insert, 0.5);

--- a/plan.txt
+++ b/plan.txt
@@ -1,6 +1,4 @@
 Possible next features (post‑diff‑viewer completeness)
 1. Conflict view (read‑only): highlight <<<<<<< / ======= / >>>>>>> and jump between them.
-2. Fold unchanged blocks: toggle to collapse long context sections.
-3. Quick file search: type‑ahead + jump (distinct from filter).
-4. Copy patch/hunk: clipboard export in unified diff format.
-5. Performance guardrails: lazy line rendering for huge files.
+2. Copy patch/hunk: clipboard export in unified diff format.
+3. Performance guardrails: lazy line rendering for huge files.


### PR DESCRIPTION
This pull request introduces a new "context folding" feature to the diff viewer, allowing users to collapse long unchanged blocks for a more focused review experience. The implementation involves both UI/UX enhancements and significant refactoring to centralize and simplify how the diff view is generated and manipulated. Several related improvements and bugfixes are also included.

**Major features and improvements:**

*Context folding feature:*
- Added a new `FoldContextMode` to the application state, with configuration and toggling support, enabling users to collapse/expand long unchanged (context) blocks in diffs. New methods for toggling and setting the mode are provided in the `App` struct. (`crates/oyo/src/app/mod.rs`, `README.md`) [[1]](diffhunk://#diff-650809e7c0cdac9d1496c76983d2931dc723c1109801873e6dfe3165ffab2ca5R135-R138) [[2]](diffhunk://#diff-650809e7c0cdac9d1496c76983d2931dc723c1109801873e6dfe3165ffab2ca5R377-R378) [[3]](diffhunk://#diff-650809e7c0cdac9d1496c76983d2931dc723c1109801873e6dfe3165ffab2ca5R674-R693) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R60) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R215) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R244)
- The diff view rendering now passes through a new `fold_context_view` utility, which filters lines based on the folding mode. This is applied consistently across navigation, blame, and file stats code paths. (`crates/oyo/src/app/mod.rs`, `crates/oyo/src/app/files.rs`, `crates/oyo/src/app/blame.rs`, `crates/oyo/src/app/navigation.rs`) [[1]](diffhunk://#diff-650809e7c0cdac9d1496c76983d2931dc723c1109801873e6dfe3165ffab2ca5R869-R876) [[2]](diffhunk://#diff-52e26cb55f8a5c40082a0b73d4eef1d0927e3deb2790b39edeb933ba0799ce15L336-R336) [[3]](diffhunk://#diff-8fdc0544745185c642e6a9ebed67fc63d61ad8fddde8cfa7cb14392448821004L42-R42)

*Navigation and blame integration:*
- All usages of the previous direct diff view access are refactored to use the new `current_view_with_frame` method, ensuring folding is respected everywhere (navigation, yank, hunk computation, etc.). (`crates/oyo/src/app/navigation.rs`, `crates/oyo/src/app/blame.rs`, `crates/oyo/src/app/files.rs`) [[1]](diffhunk://#diff-3021bd4ef09e6e302795b04f47734ebf8947498c5e50da85e826be8f39957469L123-R124) [[2]](diffhunk://#diff-3021bd4ef09e6e302795b04f47734ebf8947498c5e50da85e826be8f39957469L137-R135) [[3]](diffhunk://#diff-3021bd4ef09e6e302795b04f47734ebf8947498c5e50da85e826be8f39957469L456-R451) [[4]](diffhunk://#diff-3021bd4ef09e6e302795b04f47734ebf8947498c5e50da85e826be8f39957469L490-R482) [[5]](diffhunk://#diff-52e26cb55f8a5c40082a0b73d4eef1d0927e3deb2790b39edeb933ba0799ce15L336-R336) [[6]](diffhunk://#diff-8fdc0544745185c642e6a9ebed67fc63d61ad8fddde8cfa7cb14392448821004L42-R42)
- Blame hinting logic is updated to work correctly regardless of stepping mode, and to clear/set hints appropriately when navigating hunks. (`crates/oyo/src/app/blame.rs`, `crates/oyo/src/app/navigation.rs`) [[1]](diffhunk://#diff-8fdc0544745185c642e6a9ebed67fc63d61ad8fddde8cfa7cb14392448821004L211-R208) [[2]](diffhunk://#diff-8fdc0544745185c642e6a9ebed67fc63d61ad8fddde8cfa7cb14392448821004L634-R631) [[3]](diffhunk://#diff-3021bd4ef09e6e302795b04f47734ebf8947498c5e50da85e826be8f39957469R827) [[4]](diffhunk://#diff-3021bd4ef09e6e302795b04f47734ebf8947498c5e50da85e826be8f39957469R889-R890)

*User experience and messaging:*
- Added new keyboard shortcut documentation for toggling context folding and new config option in the README. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R215) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R244)
- Improved consistency of navigation and edge hint messages (e.g., "No more steps", "First hunk", "Last step next"). (`crates/oyo/src/app/navigation.rs`) [[1]](diffhunk://#diff-3021bd4ef09e6e302795b04f47734ebf8947498c5e50da85e826be8f39957469L286-R282) [[2]](diffhunk://#diff-3021bd4ef09e6e302795b04f47734ebf8947498c5e50da85e826be8f39957469L300-R296) [[3]](diffhunk://#diff-3021bd4ef09e6e302795b04f47734ebf8947498c5e50da85e826be8f39957469L348-R343)

*Internal refactoring and cleanup:*
- Consolidated logic for diff view access, reducing code duplication and making future changes to view filtering or folding easier. (`crates/oyo/src/app/mod.rs`, `crates/oyo/src/app/navigation.rs`, `crates/oyo/src/app/blame.rs`) [[1]](diffhunk://#diff-650809e7c0cdac9d1496c76983d2931dc723c1109801873e6dfe3165ffab2ca5R869-R876) [[2]](diffhunk://#diff-650809e7c0cdac9d1496c76983d2931dc723c1109801873e6dfe3165ffab2ca5L888-R923) [[3]](diffhunk://#diff-650809e7c0cdac9d1496c76983d2931dc723c1109801873e6dfe3165ffab2ca5L1002-R1034) [[4]](diffhunk://#diff-3021bd4ef09e6e302795b04f47734ebf8947498c5e50da85e826be8f39957469L2-R3)
- Updated hunk computation logic to correctly handle folded lines, ensuring navigation and display remain accurate when context folding is enabled. (`crates/oyo/src/app/navigation.rs`) [[1]](diffhunk://#diff-3021bd4ef09e6e302795b04f47734ebf8947498c5e50da85e826be8f39957469L544-R531) [[2]](diffhunk://#diff-3021bd4ef09e6e302795b04f47734ebf8947498c5e50da85e826be8f39957469L555-R542) [[3]](diffhunk://#diff-3021bd4ef09e6e302795b04f47734ebf8947498c5e50da85e826be8f39957469L585-R570) [[4]](diffhunk://#diff-3021bd4ef09e6e302795b04f47734ebf8947498c5e50da85e826be8f39957469L604-R589)

These changes collectively make the diff viewer more powerful and user-friendly, especially for large diffs with many unchanged lines.