### PR TITLE
Add unified diff patch copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ oyo does **not** replace classic diffs, it adds a new way to review them.
 - **Blame hints**: One-shot or toggle blame previews while stepping (opt-in)
 - **Command palette**: Search for commands and files without leaving the diff
 - **Line wrap**: Toggle wrapping for long lines
-- **Context folding**: Collapse long unchanged blocks on demand
+- **Fold unchanged blocks**: Toggle to collapse long context sections
 - **Animated transitions**: Smooth fade in/out animations as changes are applied
 - **Playback**: Automatically step through all changes at a configurable speed
 - **Git integration**: Works as a git external diff tool or standalone
@@ -206,6 +206,7 @@ command = ["oy", "$left", "$right"]
 | `Ctrl+u` | Half page up |
 | `Ctrl+d` | Half page down |
 | `Ctrl+g` | Show full file path |
+| `gy` / `gY` | Copy patch for line/hunk |
 | `Ctrl+p` | Command palette |
 | `Ctrl+Shift+p` | Quick file search |
 | `z` | Center on active change |

--- a/crates/oyo/src/main.rs
+++ b/crates/oyo/src/main.rs
@@ -1038,6 +1038,12 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> Result<AppE
                         let is_blame_gb = matches!(key.code, KeyCode::Char('b'))
                             && !key.modifiers.contains(KeyModifiers::CONTROL)
                             && !key.modifiers.contains(KeyModifiers::ALT);
+                        let is_patch_line = matches!(key.code, KeyCode::Char('y'))
+                            && !key.modifiers.contains(KeyModifiers::CONTROL)
+                            && !key.modifiers.contains(KeyModifiers::ALT);
+                        let is_patch_hunk = matches!(key.code, KeyCode::Char('Y'))
+                            && !key.modifiers.contains(KeyModifiers::CONTROL)
+                            && !key.modifiers.contains(KeyModifiers::ALT);
                         if is_plain_g {
                             app.pending_g_prefix = false;
                             app.reset_count();
@@ -1050,6 +1056,18 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> Result<AppE
                             if app.blame_enabled {
                                 app.trigger_blame_hint();
                             }
+                            continue;
+                        }
+                        if is_patch_line {
+                            app.pending_g_prefix = false;
+                            app.reset_count();
+                            app.yank_current_change_patch();
+                            continue;
+                        }
+                        if is_patch_hunk {
+                            app.pending_g_prefix = false;
+                            app.reset_count();
+                            app.yank_current_hunk_patch();
                             continue;
                         }
                         app.pending_g_prefix = false;

--- a/crates/oyo/src/ui.rs
+++ b/crates/oyo/src/ui.rs
@@ -1239,6 +1239,7 @@ fn draw_help_popover(frame: &mut Frame, app: &mut App) {
     push_help_line(&mut lines, "p", "Peek change");
     push_help_line(&mut lines, "P", "Peek old hunk");
     push_help_line(&mut lines, "y / Y", "Yank line/hunk");
+    push_help_line(&mut lines, "g y / g Y", "Copy patch (line/hunk)");
     push_help_line(&mut lines, "/", "Search (diff pane)");
     push_help_line(&mut lines, "n / N", "Next/prev match");
     push_help_line(&mut lines, ":<line>", "Go to line");


### PR DESCRIPTION
This pull request adds a new feature to allow users to copy ("yank") the patch for the current line or hunk directly to the clipboard, both via new keyboard shortcuts and from the command palette. It also updates the documentation and help popover to reflect these new commands, and clarifies some terminology in the README.

**New yank patch feature:**

* Added methods `yank_current_change_patch` and `yank_current_hunk_patch` to the `App` struct, enabling users to copy the patch for the current line or hunk to the clipboard. Supporting helpers for patch formatting were also implemented. (`crates/oyo/src/app/navigation.rs`)
* Integrated new keyboard shortcuts (`gy` / `gY`) for copying the patch for the current line or hunk, and updated the main event loop to handle these commands. (`crates/oyo/src/main.rs`) [[1]](diffhunk://#diff-0ec0e6cffbee945c586b7082a5fa3181550e8a67797f9c6ce8e5f68153a20c27R1041-R1046) [[2]](diffhunk://#diff-0ec0e6cffbee945c586b7082a5fa3181550e8a67797f9c6ce8e5f68153a20c27R1061-R1072)

**User interface and documentation updates:**

* Updated the help popover to document the new yank patch commands. (`crates/oyo/src/ui.rs`)
* Added the new keybindings to the shortcut table in the README. (`README.md`)

**Terminology improvement:**

* Clarified the terminology in the README, changing "Context folding" to "Fold unchanged blocks" for better clarity. (`README.md`)