### PR TITLE
Conflict navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ command = ["oy", "$left", "$right"]
 | `f` | Toggle context folding |
 | `t` | Toggle syntax highlight |
 | `E` | Toggle evo syntax (context/full) |
+| `c` / `C` | Next/prev conflict |
 | `s` | Toggle stepping (no-step mode) |
 | `S` | Toggle strikethrough |
 | `r` | Replay last step (count supported) |

--- a/crates/oyo-core/src/step.rs
+++ b/crates/oyo-core/src/step.rs
@@ -168,6 +168,14 @@ impl DiffNavigator {
         self.state.cursor_change = change_id;
     }
 
+    /// Override the active cursor without changing applied steps.
+    pub fn set_cursor_override(&mut self, change_id: Option<usize>) {
+        self.state.cursor_change = change_id;
+        self.state.active_change = None;
+        self.state.step_direction = StepDirection::None;
+        self.state.animating_hunk = None;
+    }
+
     /// Set cursor change without altering current hunk.
     pub fn set_cursor_change(&mut self, change_id: Option<usize>) {
         self.state.cursor_change = change_id;

--- a/crates/oyo/src/app/mod.rs
+++ b/crates/oyo/src/app/mod.rs
@@ -36,7 +36,7 @@ use types::{
     StepEdgeHint, SyntaxScopeCache,
 };
 use utils::{allow_overscroll_state, max_scroll};
-pub(crate) use utils::{display_metrics, is_fold_line};
+pub(crate) use utils::{display_metrics, is_conflict_marker, is_fold_line};
 
 /// The main application state
 pub struct App {

--- a/crates/oyo/src/app/utils.rs
+++ b/crates/oyo/src/app/utils.rs
@@ -125,6 +125,11 @@ pub(crate) fn match_ranges(text: &str, regex: &Regex) -> Vec<(usize, usize)> {
     ranges
 }
 
+pub(crate) fn is_conflict_marker(line: &ViewLine) -> bool {
+    let text = line.content.trim_start();
+    text.starts_with("<<<<<<<") || text.starts_with("=======") || text.starts_with(">>>>>>>")
+}
+
 pub(crate) fn apply_highlight_spans(
     spans: Vec<Span<'static>>,
     ranges: &[(usize, usize)],

--- a/crates/oyo/src/main.rs
+++ b/crates/oyo/src/main.rs
@@ -1437,6 +1437,14 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> Result<AppE
                             app.reset_count();
                             app.search_prev();
                         }
+                        KeyCode::Char('c') => {
+                            app.reset_count();
+                            app.next_conflict();
+                        }
+                        KeyCode::Char('C') => {
+                            app.reset_count();
+                            app.prev_conflict();
+                        }
                         KeyCode::Char('?') => {
                             app.reset_count();
                             // Toggle help popover

--- a/crates/oyo/src/ui.rs
+++ b/crates/oyo/src/ui.rs
@@ -1242,6 +1242,7 @@ fn draw_help_popover(frame: &mut Frame, app: &mut App) {
     push_help_line(&mut lines, "g y / g Y", "Copy patch (line/hunk)");
     push_help_line(&mut lines, "/", "Search (diff pane)");
     push_help_line(&mut lines, "n / N", "Next/prev match");
+    push_help_line(&mut lines, "c / C", "Next/prev conflict");
     push_help_line(&mut lines, ":<line>", "Go to line");
     push_help_line(&mut lines, ":h<num>", "Go to hunk");
     push_help_line(&mut lines, ":s<num>", "Go to step");

--- a/crates/oyo/src/views/evolution.rs
+++ b/crates/oyo/src/views/evolution.rs
@@ -6,7 +6,7 @@ use super::{
     spans_width, truncate_text, view_spans_to_text, wrap_count_for_spans, wrap_count_for_text,
     TAB_WIDTH,
 };
-use crate::app::{is_fold_line, AnimationPhase, App};
+use crate::app::{is_conflict_marker, is_fold_line, AnimationPhase, App};
 use crate::syntax::SyntaxSide;
 use oyo_core::{LineKind, StepDirection, ViewLine, ViewSpanKind};
 use ratatui::{
@@ -518,6 +518,16 @@ pub fn render_evolution(frame: &mut Frame, app: &mut App, area: Rect) {
             && has_query
             && line_text.to_ascii_lowercase().contains(&query);
         content_spans = app.highlight_search_spans(content_spans, &line_text, is_active_match);
+        if is_conflict_marker(view_line) {
+            content_spans = content_spans
+                .into_iter()
+                .map(|span| {
+                    let mut style = span.style;
+                    style = style.fg(app.theme.warning).add_modifier(Modifier::BOLD);
+                    Span::styled(span.content, style)
+                })
+                .collect();
+        }
 
         content_spans = expand_tabs_in_spans(&content_spans, TAB_WIDTH);
 

--- a/crates/oyo/src/views/split.rs
+++ b/crates/oyo/src/views/split.rs
@@ -5,7 +5,7 @@ use super::{
     pad_spans_bg, pending_tail_text, render_empty_state, slice_spans, spans_to_text, spans_width,
     truncate_text, view_spans_to_text, wrap_count_for_spans, wrap_count_for_text, TAB_WIDTH,
 };
-use crate::app::{is_fold_line, AnimationPhase, App};
+use crate::app::{is_conflict_marker, is_fold_line, AnimationPhase, App};
 use crate::color;
 use crate::config::{DiffForegroundMode, DiffHighlightMode};
 use crate::syntax::SyntaxSide;
@@ -804,6 +804,16 @@ fn render_old_pane(
             if italic_line {
                 content_spans = super::apply_italic_spans(content_spans);
             }
+            if is_conflict_marker(view_line) {
+                content_spans = content_spans
+                    .into_iter()
+                    .map(|span| {
+                        let mut style = span.style;
+                        style = style.fg(app.theme.warning).add_modifier(Modifier::BOLD);
+                        Span::styled(span.content, style)
+                    })
+                    .collect();
+            }
 
             content_spans = expand_tabs_in_spans(&content_spans, TAB_WIDTH);
 
@@ -1580,6 +1590,16 @@ fn render_new_pane(
             content_spans = app.highlight_search_spans(content_spans, &line_text, is_active_match);
             if italic_line {
                 content_spans = super::apply_italic_spans(content_spans);
+            }
+            if is_conflict_marker(view_line) {
+                content_spans = content_spans
+                    .into_iter()
+                    .map(|span| {
+                        let mut style = span.style;
+                        style = style.fg(app.theme.warning).add_modifier(Modifier::BOLD);
+                        Span::styled(span.content, style)
+                    })
+                    .collect();
             }
 
             content_spans = expand_tabs_in_spans(&content_spans, TAB_WIDTH);

--- a/crates/oyo/src/views/unified_pane.rs
+++ b/crates/oyo/src/views/unified_pane.rs
@@ -5,7 +5,7 @@ use super::{
     pad_spans_bg, pending_tail_text, render_empty_state, slice_spans, spans_to_text, spans_width,
     truncate_text, wrap_count_for_spans, wrap_count_for_text, TAB_WIDTH,
 };
-use crate::app::{is_fold_line, AnimationPhase, App};
+use crate::app::{is_conflict_marker, is_fold_line, AnimationPhase, App};
 use crate::color;
 use crate::config::{DiffForegroundMode, DiffHighlightMode, ModifiedStepMode};
 use crate::syntax::SyntaxSide;
@@ -920,6 +920,16 @@ pub fn render_unified_pane(frame: &mut Frame, app: &mut App, area: Rect) {
         content_spans = app.highlight_search_spans(content_spans, &line_text, is_active_match);
         if italic_line {
             content_spans = super::apply_italic_spans(content_spans);
+        }
+        if is_conflict_marker(view_line) {
+            content_spans = content_spans
+                .into_iter()
+                .map(|span| {
+                    let mut style = span.style;
+                    style = style.fg(app.theme.warning).add_modifier(Modifier::BOLD);
+                    Span::styled(span.content, style)
+                })
+                .collect();
         }
 
         if app.line_wrap {

--- a/plan.txt
+++ b/plan.txt
@@ -1,4 +1,2 @@
 Possible next features (post‑diff‑viewer completeness)
-1. Conflict view (read‑only): highlight <<<<<<< / ======= / >>>>>>> and jump between them.
-2. Copy patch/hunk: clipboard export in unified diff format.
-3. Performance guardrails: lazy line rendering for huge files.
+1. Performance guardrails: lazy line rendering for huge files.


### PR DESCRIPTION
This pull request introduces a comprehensive "conflict marker" navigation and highlighting feature to the diff viewer. Users can now quickly jump to the next or previous merge conflict marker (e.g., `<<<<<<<`, `=======`, `>>>>>>>`) in diffs, and these markers are visually highlighted for clarity. The update includes new keyboard shortcuts, UI enhancements, and thorough test coverage for the new navigation logic.

**Conflict marker navigation and highlighting:**

* Added detection of conflict markers in diff lines and changes, with a new utility function `is_conflict_marker` in `utils.rs`. [[1]](diffhunk://#diff-3b5a17e37b6aade438bea214c4b6de963debdbf39bb9e45811626b7ca72746f6R128-R132) [[2]](diffhunk://#diff-650809e7c0cdac9d1496c76983d2931dc723c1109801873e6dfe3165ffab2ca5L39-R39) [[3]](diffhunk://#diff-3021bd4ef09e6e302795b04f47734ebf8947498c5e50da85e826be8f39957469L2-R7) [[4]](diffhunk://#diff-7c2d0974bcc4dd98f27217266a4a4fb3864014743d62ba5b898735999e9ea2b7L9-R9) [[5]](diffhunk://#diff-375f5f0a3d6785791aedabf1850e1a72e7fc905cc2938d08ca24a7bd70fdb6aeL8-R8) [[6]](diffhunk://#diff-e94eaf4c34493f804e5603f79e553868fbe26421a2798aceb952b403e7fd6d69L8-R8)
* Implemented navigation commands (`next_conflict`, `prev_conflict`) in `App`, allowing users to jump between conflict markers, with logic to handle different view modes and step states.
* Mapped new keyboard shortcuts (`c`/`C`) to conflict navigation in the main event loop and documented them in the help popover and README. [[1]](diffhunk://#diff-0ec0e6cffbee945c586b7082a5fa3181550e8a67797f9c6ce8e5f68153a20c27R1440-R1447) [[2]](diffhunk://#diff-bc03091be2942ced1861b3008112813bb5fd37c2c77c8e75bb91b9cdfa0fd2c6R1245) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R219)
* Visually highlighted conflict marker lines in all diff views (unified, split, and evolution) by rendering them in bold and with a warning color. [[1]](diffhunk://#diff-7c2d0974bcc4dd98f27217266a4a4fb3864014743d62ba5b898735999e9ea2b7R521-R530) [[2]](diffhunk://#diff-375f5f0a3d6785791aedabf1850e1a72e7fc905cc2938d08ca24a7bd70fdb6aeR807-R816) [[3]](diffhunk://#diff-375f5f0a3d6785791aedabf1850e1a72e7fc905cc2938d08ca24a7bd70fdb6aeR1594-R1603) [[4]](diffhunk://#diff-e94eaf4c34493f804e5603f79e553868fbe26421a2798aceb952b403e7fd6d69R924-R933)
* Added thorough unit tests for conflict navigation logic to ensure correct step transitions and marker detection.

**Supporting changes:**

* Added a new method `set_cursor_override` to `DiffNavigator` to support cursor movement without changing applied steps.
* Updated the project plan to mark "conflict view" as implemented.