### PR TITLE
update virtual text

### DIFF
--- a/crates/oyo/src/views/mod.rs
+++ b/crates/oyo/src/views/mod.rs
@@ -73,7 +73,7 @@ pub(crate) fn boost_inline_bg(app: &App, base_bg: Option<Color>, accent: Color) 
 }
 
 pub(crate) fn pending_tail_text(count: usize) -> String {
-    format!("+{} More", count)
+    format!("… +{} steps", count)
 }
 
 pub(crate) fn diff_line_bg(kind: LineKind, theme: &ResolvedTheme) -> Option<Color> {


### PR DESCRIPTION
This pull request makes a small change to the formatting of the pending steps text in the UI. The text now uses an ellipsis and a more descriptive label for clarity.

- UI text improvement:
  * Updated the pending steps indicator in `pending_tail_text` to display as "… +N steps" instead of "+N More" for better clarity and consistency.