### PR TITLE
Skip large files when building diffs

### DIFF
--- a/crates/oyo-core/src/git.rs
+++ b/crates/oyo-core/src/git.rs
@@ -333,6 +333,23 @@ pub fn get_file_at_commit_bytes(
     Ok(output.stdout)
 }
 
+pub fn get_file_at_commit_size(repo_path: &Path, commit: &str, file: &Path) -> Option<u64> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo_path)
+        .arg("cat-file")
+        .arg("-s")
+        .arg(format!("{}:{}", commit, file.display()))
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    String::from_utf8_lossy(&output.stdout).trim().parse().ok()
+}
+
 /// Get the staged content of a file
 pub fn get_staged_content(repo_path: &Path, file: &Path) -> Result<String, GitError> {
     let output = Command::new("git")
@@ -363,6 +380,23 @@ pub fn get_staged_content_bytes(repo_path: &Path, file: &Path) -> Result<Vec<u8>
     }
 
     Ok(output.stdout)
+}
+
+pub fn get_staged_content_size(repo_path: &Path, file: &Path) -> Option<u64> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo_path)
+        .arg("cat-file")
+        .arg("-s")
+        .arg(format!(":{}", file.display()))
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    String::from_utf8_lossy(&output.stdout).trim().parse().ok()
 }
 
 pub fn get_head_content_bytes(repo_path: &Path, file: &Path) -> Result<Vec<u8>, GitError> {


### PR DESCRIPTION
This pull request introduces logic to efficiently handle large files in multi-file diffs by checking file sizes before loading their content, and refactors how file content is read from the filesystem and git objects. The main goal is to avoid loading or diffing files larger than 2MB, treating them as binary for performance and safety. Several helper functions are added for querying file sizes from both the filesystem and git history, and the code is refactored to consistently use these helpers throughout the diffing logic.

**Large file handling and binary detection:**
- Introduced a 2MB size limit (`MAX_FILE_BYTES`) for files in `MultiFileDiff`; files exceeding this size are treated as binary and their content is not loaded. [[1]](diffhunk://#diff-1b49853a5d12d2f5e9c39f0433ad6dafffe3bc55f99f0b016829c328d6ed5861R65-R66) [[2]](diffhunk://#diff-1b49853a5d12d2f5e9c39f0433ad6dafffe3bc55f99f0b016829c328d6ed5861R77-R110)
- Refactored all file content loading code paths (working directory, staged, committed, and ranged diffs) to check file size before reading, using new helper methods. [[1]](diffhunk://#diff-1b49853a5d12d2f5e9c39f0433ad6dafffe3bc55f99f0b016829c328d6ed5861L115-R126) [[2]](diffhunk://#diff-1b49853a5d12d2f5e9c39f0433ad6dafffe3bc55f99f0b016829c328d6ed5861L182-R194) [[3]](diffhunk://#diff-1b49853a5d12d2f5e9c39f0433ad6dafffe3bc55f99f0b016829c328d6ed5861L253-R266) [[4]](diffhunk://#diff-1b49853a5d12d2f5e9c39f0433ad6dafffe3bc55f99f0b016829c328d6ed5861L344-R330) [[5]](diffhunk://#diff-1b49853a5d12d2f5e9c39f0433ad6dafffe3bc55f99f0b016829c328d6ed5861L430-R436) [[6]](diffhunk://#diff-1b49853a5d12d2f5e9c39f0433ad6dafffe3bc55f99f0b016829c328d6ed5861L759-R817)

**New helper functions for file size:**
- Added `get_file_at_commit_size` and `get_staged_content_size` in `git.rs` to efficiently query file sizes in git history and index without loading full content. [[1]](diffhunk://#diff-3dd40592daca4600ed6656c09108f47ddcc83cfe1c913acc124d2b325ae98848R336-R352) [[2]](diffhunk://#diff-3dd40592daca4600ed6656c09108f47ddcc83cfe1c913acc124d2b325ae98848R385-R401)
- Added new helper methods in `MultiFileDiff` for reading file content or treating as binary based on size, for both git and filesystem sources.

**Refactoring and code simplification:**
- Removed the old `diff_from_bytes` method in favor of in-place logic that checks for binary files and computes diffs only for files under the size limit. [[1]](diffhunk://#diff-1b49853a5d12d2f5e9c39f0433ad6dafffe3bc55f99f0b016829c328d6ed5861R77-R110) [[2]](diffhunk://#diff-1b49853a5d12d2f5e9c39f0433ad6dafffe3bc55f99f0b016829c328d6ed5861L759-R817)
- Updated all usages of raw byte reading from git and filesystem to use the new helpers, improving consistency and maintainability. [[1]](diffhunk://#diff-1b49853a5d12d2f5e9c39f0433ad6dafffe3bc55f99f0b016829c328d6ed5861L115-R126) [[2]](diffhunk://#diff-1b49853a5d12d2f5e9c39f0433ad6dafffe3bc55f99f0b016829c328d6ed5861L182-R194) [[3]](diffhunk://#diff-1b49853a5d12d2f5e9c39f0433ad6dafffe3bc55f99f0b016829c328d6ed5861L253-R266) [[4]](diffhunk://#diff-1b49853a5d12d2f5e9c39f0433ad6dafffe3bc55f99f0b016829c328d6ed5861L344-R330) [[5]](diffhunk://#diff-1b49853a5d12d2f5e9c39f0433ad6dafffe3bc55f99f0b016829c328d6ed5861L430-R436) [[6]](diffhunk://#diff-1b49853a5d12d2f5e9c39f0433ad6dafffe3bc55f99f0b016829c328d6ed5861L759-R817)

**Minor cleanups:**
- Removed an unused import in `multi.rs`.