### PR TITLE
multi-system support and package definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ node_modules/
 # Nix/direnv
 .direnv/
 .envrc
+result

--- a/flake.lock
+++ b/flake.lock
@@ -35,7 +35,8 @@
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
+        "rust-overlay": "rust-overlay",
+        "systems": "systems"
       }
     },
     "rust-overlay": {
@@ -53,6 +54,21 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }


### PR DESCRIPTION
Cleaned up the `flake.nix` to get rid of the hardcoded `aarch64-darwin` system. It now uses `nix-systems` so it's actually portable across Linux and other architectures.

I also added a proper package definition for `oyo`. This means you can build or run it directly without needing to enter a dev shell.

### What's new
* **Multi-system**: Works on Linux and Darwin now.
* **Package**: Defined `oyo` (and `default`). It reads the version directly from `Cargo.toml`.
* **DevShell**: Now system-agnostic; kept `bacon` and `pkg-config` in there.
* **Git**: Added `result` to `.gitignore`.

### Try it out

```bash
# run locally
nix run .

# run from github
nix run github:lukasl-dev/oyo

# build binary to ./result
nix build .
```