### PR TITLE
fix: prefer editable files for editor opens

### DIFF
--- a/crates/oyo-core/src/multi.rs
+++ b/crates/oyo-core/src/multi.rs
@@ -24,11 +24,25 @@ pub enum MultiDiffError {
 pub struct FileEntry {
     pub path: PathBuf,
     pub old_path: Option<PathBuf>,
+    pub old_source_path: Option<PathBuf>,
+    pub new_source_path: Option<PathBuf>,
     pub display_name: String,
     pub status: FileStatus,
     pub insertions: usize,
     pub deletions: usize,
     pub binary: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileSide {
+    Old,
+    New,
+}
+
+#[derive(Debug, Clone)]
+struct SourceRoots {
+    old: PathBuf,
+    new: PathBuf,
 }
 
 /// Multi-file diff session
@@ -46,6 +60,8 @@ pub struct MultiFileDiff {
     repo_root: Option<PathBuf>,
     /// Git diff mode (if in git mode)
     git_mode: Option<GitDiffMode>,
+    /// Real file roots for non-git diffs, when known.
+    source_roots: Option<SourceRoots>,
     /// Old contents for each file
     old_contents: Vec<Arc<str>>,
     /// New contents for each file
@@ -344,6 +360,8 @@ impl MultiFileDiff {
                 display_name: change.path.display().to_string(),
                 path: change.path,
                 old_path: change.old_path,
+                old_source_path: None,
+                new_source_path: None,
                 status: change.status,
                 insertions,
                 deletions,
@@ -366,6 +384,7 @@ impl MultiFileDiff {
             navigator_is_placeholder,
             repo_root: Some(repo_root),
             git_mode: Some(GitDiffMode::Uncommitted),
+            source_roots: None,
             old_contents,
             new_contents,
             precomputed_diffs,
@@ -407,6 +426,8 @@ impl MultiFileDiff {
                 display_name: change.path.display().to_string(),
                 path: change.path,
                 old_path: change.old_path,
+                old_source_path: None,
+                new_source_path: None,
                 status: change.status,
                 insertions,
                 deletions,
@@ -429,6 +450,7 @@ impl MultiFileDiff {
             navigator_is_placeholder,
             repo_root: Some(repo_root),
             git_mode: Some(GitDiffMode::Staged),
+            source_roots: None,
             old_contents,
             new_contents,
             precomputed_diffs,
@@ -484,6 +506,8 @@ impl MultiFileDiff {
                 display_name: change.path.display().to_string(),
                 path: change.path,
                 old_path: change.old_path,
+                old_source_path: None,
+                new_source_path: None,
                 status: change.status,
                 insertions,
                 deletions,
@@ -506,6 +530,7 @@ impl MultiFileDiff {
             navigator_is_placeholder,
             repo_root: Some(repo_root),
             git_mode: Some(GitDiffMode::IndexRange { from, to_index }),
+            source_roots: None,
             old_contents,
             new_contents,
             precomputed_diffs,
@@ -549,6 +574,8 @@ impl MultiFileDiff {
                 display_name: change.path.display().to_string(),
                 path: change.path,
                 old_path: change.old_path,
+                old_source_path: None,
+                new_source_path: None,
                 status: change.status,
                 insertions,
                 deletions,
@@ -571,6 +598,7 @@ impl MultiFileDiff {
             navigator_is_placeholder,
             repo_root: Some(repo_root),
             git_mode: Some(GitDiffMode::Range { from, to }),
+            source_roots: None,
             old_contents,
             new_contents,
             precomputed_diffs,
@@ -666,6 +694,8 @@ impl MultiFileDiff {
                 display_name: rel_path.display().to_string(),
                 path: rel_path,
                 old_path: None,
+                old_source_path: None,
+                new_source_path: None,
                 status,
                 insertions,
                 deletions,
@@ -688,6 +718,10 @@ impl MultiFileDiff {
             navigator_is_placeholder,
             repo_root: None,
             git_mode: None,
+            source_roots: Some(SourceRoots {
+                old: old_dir.to_path_buf(),
+                new: new_dir.to_path_buf(),
+            }),
             old_contents,
             new_contents,
             precomputed_diffs,
@@ -702,11 +736,27 @@ impl MultiFileDiff {
         old_content: String,
         new_content: String,
     ) -> Self {
-        Self::from_file_pair_bytes(new_path, old_content.into_bytes(), new_content.into_bytes())
+        Self::from_file_pair_with_sources(
+            new_path.clone(),
+            old_content.into_bytes(),
+            new_content.into_bytes(),
+            None,
+            Some(new_path),
+        )
     }
 
     /// Create from a single file pair (bytes, with binary detection).
     pub fn from_file_pair_bytes(new_path: PathBuf, old_bytes: Vec<u8>, new_bytes: Vec<u8>) -> Self {
+        Self::from_file_pair_with_sources(new_path, old_bytes, new_bytes, None, None)
+    }
+
+    pub fn from_file_pair_with_sources(
+        new_path: PathBuf,
+        old_bytes: Vec<u8>,
+        new_bytes: Vec<u8>,
+        old_source: Option<PathBuf>,
+        new_source: Option<PathBuf>,
+    ) -> Self {
         let (old_content, old_binary) = Self::decode_bytes(old_bytes);
         let (new_content, new_binary) = Self::decode_bytes(new_bytes);
         let binary = old_binary || new_binary;
@@ -718,6 +768,8 @@ impl MultiFileDiff {
             display_name: new_path.display().to_string(),
             path: new_path,
             old_path: None,
+            old_source_path: old_source,
+            new_source_path: new_source,
             status: FileStatus::Modified,
             insertions,
             deletions,
@@ -731,6 +783,7 @@ impl MultiFileDiff {
             navigator_is_placeholder: vec![false],
             repo_root: None,
             git_mode: None,
+            source_roots: None,
             old_contents: vec![Arc::from(old_content)],
             new_contents: vec![Arc::from(new_content)],
             precomputed_diffs: vec![precomputed],
@@ -757,6 +810,8 @@ impl MultiFileDiff {
                 display_name: path.display().to_string(),
                 path,
                 old_path: None,
+                old_source_path: None,
+                new_source_path: None,
                 status: FileStatus::Modified,
                 insertions,
                 deletions,
@@ -775,6 +830,7 @@ impl MultiFileDiff {
             navigator_is_placeholder: vec![false; old_contents.len()],
             repo_root: None,
             git_mode: None,
+            source_roots: None,
             old_contents,
             new_contents,
             precomputed_diffs,
@@ -834,6 +890,54 @@ impl MultiFileDiff {
         let old = self.old_contents.get(idx)?;
         let new = self.new_contents.get(idx)?;
         Some((old.clone(), new.clone()))
+    }
+
+    pub fn set_source_roots(&mut self, old: PathBuf, new: PathBuf) {
+        self.source_roots = Some(SourceRoots { old, new });
+    }
+
+    pub fn clear_source_roots(&mut self) {
+        self.source_roots = None;
+    }
+
+    pub fn source_path(&self, idx: usize, side: FileSide) -> Option<PathBuf> {
+        let file = self.files.get(idx)?;
+        if let Some(path) = match side {
+            FileSide::Old => file.old_source_path.as_ref(),
+            FileSide::New => file.new_source_path.as_ref(),
+        } {
+            return Some(path.clone());
+        }
+
+        let rel_path = match side {
+            FileSide::Old => file.old_path.as_ref().or_else(|| {
+                if self.source_roots.is_some() || self.repo_root.is_some() {
+                    Some(&file.path)
+                } else {
+                    None
+                }
+            })?,
+            FileSide::New => &file.path,
+        };
+
+        if rel_path.is_absolute() {
+            return Some(rel_path.clone());
+        }
+
+        if let Some(roots) = &self.source_roots {
+            let root = match side {
+                FileSide::Old => &roots.old,
+                FileSide::New => &roots.new,
+            };
+            return Some(root.join(rel_path));
+        }
+
+        self.repo_root.as_ref().map(|root| root.join(rel_path))
+    }
+
+    pub fn existing_source_path(&self, idx: usize, side: FileSide) -> Option<PathBuf> {
+        let path = self.source_path(idx, side)?;
+        path.is_file().then_some(path)
     }
 
     /// Check if the current file is binary
@@ -1184,6 +1288,8 @@ impl MultiFileDiff {
                 display_name: change.path.display().to_string(),
                 path: change.path,
                 old_path: change.old_path,
+                old_source_path: None,
+                new_source_path: None,
                 status: change.status,
                 insertions,
                 deletions,
@@ -1284,13 +1390,17 @@ impl MultiFileDiff {
                     }
                 }
                 _ => {
-                    let (new_content, new_binary) = Self::read_text_or_binary(&file.path);
-                    (
-                        self.old_contents[idx].as_ref().to_string(),
-                        false,
-                        new_content,
-                        new_binary,
-                    )
+                    let old_content = self.old_contents[idx].as_ref().to_string();
+                    let (old_content, old_binary) = self
+                        .source_path(idx, FileSide::Old)
+                        .filter(|path| path.is_file())
+                        .map(|path| Self::read_text_or_binary(&path))
+                        .unwrap_or((old_content, false));
+                    let new_path = self
+                        .source_path(idx, FileSide::New)
+                        .unwrap_or_else(|| file.path.clone());
+                    let (new_content, new_binary) = Self::read_text_or_binary(&new_path);
+                    (old_content, old_binary, new_content, new_binary)
                 }
             };
 
@@ -1479,6 +1589,53 @@ mod tests {
 
         let diff = MultiFileDiff::from_directories(&old_dir, &new_dir).unwrap();
         assert!(!display_names(&diff).contains(&".git/config".to_string()));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn directory_diff_exposes_source_paths() {
+        let root = temp_dir("source-paths");
+        let old_dir = root.join("old");
+        let new_dir = root.join("new");
+        write_file(&old_dir.join("file.txt"), "old\n");
+        write_file(&new_dir.join("file.txt"), "new\n");
+
+        let diff = MultiFileDiff::from_directories(&old_dir, &new_dir).unwrap();
+        assert_eq!(
+            diff.existing_source_path(0, FileSide::Old),
+            Some(old_dir.join("file.txt"))
+        );
+        assert_eq!(
+            diff.existing_source_path(0, FileSide::New),
+            Some(new_dir.join("file.txt"))
+        );
+
+        write_file(&old_dir.join("file.txt"), "older\n");
+        let mut diff = diff;
+        diff.refresh_current_file();
+        assert_eq!(diff.file_contents(0).map(|(old, _)| old), Some("older\n"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn file_pair_exposes_explicit_source_path() {
+        let root = temp_dir("file-pair-source");
+        let old_path = root.join("old.txt");
+        let new_path = root.join("new.txt");
+        write_file(&old_path, "old\n");
+        write_file(&new_path, "new\n");
+
+        let diff = MultiFileDiff::from_file_pair_with_sources(
+            PathBuf::from("display.txt"),
+            b"old\n".to_vec(),
+            b"new\n".to_vec(),
+            Some(old_path.clone()),
+            Some(new_path.clone()),
+        );
+        assert_eq!(diff.existing_source_path(0, FileSide::Old), Some(old_path));
+        assert_eq!(diff.existing_source_path(0, FileSide::New), Some(new_path));
 
         let _ = std::fs::remove_dir_all(root);
     }

--- a/crates/oyo/src/app/files.rs
+++ b/crates/oyo/src/app/files.rs
@@ -1,4 +1,5 @@
 use super::{AnimationPhase, App, FileDiskStamp, ViewMode};
+use oyo_core::multi::FileSide;
 use std::time::{Duration, Instant};
 
 impl App {
@@ -313,11 +314,16 @@ impl App {
             return FileDiskStamp::default();
         };
 
-        let full_path = if let Some(repo_root) = self.multi_diff.repo_root() {
-            repo_root.join(&file.path)
-        } else {
-            file.path.clone()
-        };
+        let full_path = self
+            .multi_diff
+            .source_path(idx, FileSide::New)
+            .unwrap_or_else(|| {
+                if let Some(repo_root) = self.multi_diff.repo_root() {
+                    repo_root.join(&file.path)
+                } else {
+                    file.path.clone()
+                }
+            });
 
         match std::fs::metadata(&full_path) {
             Ok(meta) => FileDiskStamp {

--- a/crates/oyo/src/main.rs
+++ b/crates/oyo/src/main.rs
@@ -26,7 +26,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use oyo_core::{multi::BlameSource, DirectoryScanOptions, LineKind, MultiFileDiff, ViewLine};
+use oyo_core::{multi::FileSide, DirectoryScanOptions, LineKind, MultiFileDiff, ViewLine};
 use ratatui::prelude::*;
 use std::fs::OpenOptions;
 use std::io::{self, IsTerminal};
@@ -293,6 +293,50 @@ fn looks_like_jj_external_diff_dirs(old_path: &Path, new_path: &Path) -> bool {
         .unwrap_or(false)
 }
 
+fn is_jj_diff_dir(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.starts_with("jj-diff-"))
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "linux")]
+fn parent_pid(pid: u32) -> Option<u32> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let (_, after_name) = stat.rsplit_once(") ")?;
+    let mut fields = after_name.split_whitespace();
+    fields.next()?;
+    fields.next()?.parse().ok()
+}
+
+#[cfg(not(target_os = "linux"))]
+fn parent_pid(_pid: u32) -> Option<u32> {
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn process_cwd(pid: u32) -> Option<PathBuf> {
+    std::fs::read_link(format!("/proc/{pid}/cwd")).ok()
+}
+
+#[cfg(not(target_os = "linux"))]
+fn process_cwd(_pid: u32) -> Option<PathBuf> {
+    None
+}
+
+fn infer_external_diff_workspace_root() -> Option<PathBuf> {
+    let mut pid = parent_pid(std::process::id())?;
+    for _ in 0..8 {
+        if let Some(cwd) = process_cwd(pid) {
+            if cwd.is_dir() && !is_jj_diff_dir(&cwd) {
+                return Some(cwd);
+            }
+        }
+        pid = parent_pid(pid)?;
+    }
+    None
+}
+
 fn directory_scan_options(
     config: &config::Config,
     args: &Args,
@@ -387,17 +431,17 @@ fn current_editor_target(app: &mut App, needs_line: bool) -> Result<Option<Edito
         EditorSide::New => file.path.clone(),
     };
 
-    if side == EditorSide::New {
-        if let (Some(root), Some((_, BlameSource::Worktree))) =
-            (app.multi_diff.repo_root(), app.multi_diff.blame_sources())
-        {
-            return Ok(Some(EditorTarget {
-                path: root.join(&file.path),
-                line,
-                cwd: Some(root.to_path_buf()),
-                refresh_after_edit: true,
-            }));
-        }
+    let file_side = match side {
+        EditorSide::Old => FileSide::Old,
+        EditorSide::New => FileSide::New,
+    };
+    if let Some(path) = app.multi_diff.existing_source_path(file_index, file_side) {
+        return Ok(Some(EditorTarget {
+            path,
+            line,
+            cwd: app.multi_diff.repo_root().map(Path::to_path_buf),
+            refresh_after_edit: true,
+        }));
     }
 
     let Some((old_content, new_content)) = app.multi_diff.file_contents(file_index) else {
@@ -806,15 +850,31 @@ fn build_diff_from_input_mode(
                 oyo_core::git::get_current_branch(&std::env::current_dir().unwrap_or_default())
                     .ok();
 
-            let diff =
-                MultiFileDiff::from_file_pair_bytes(display_path.clone(), old_bytes, new_bytes);
+            let cwd = std::env::current_dir().unwrap_or_default();
+            let new_source = cwd.join(display_path);
+            let diff = MultiFileDiff::from_file_pair_with_sources(
+                display_path.clone(),
+                old_bytes,
+                new_bytes,
+                None,
+                Some(new_source),
+            );
             (diff, branch)
         }
         InputMode::TwoPaths { old_path, new_path } => {
             let diff = if old_path.is_dir() && new_path.is_dir() {
                 let scan_options = directory_scan_options(config, args, old_path, new_path);
-                MultiFileDiff::from_directories_with_options(old_path, new_path, &scan_options)
-                    .context("Failed to create diff from directories")?
+                let mut diff =
+                    MultiFileDiff::from_directories_with_options(old_path, new_path, &scan_options)
+                        .context("Failed to create diff from directories")?;
+                if looks_like_jj_external_diff_dirs(old_path, new_path) {
+                    if let Some(root) = infer_external_diff_workspace_root() {
+                        diff.set_source_roots(root.clone(), root);
+                    } else {
+                        diff.clear_source_roots();
+                    }
+                }
+                diff
             } else {
                 let old_bytes = if old_path.to_string_lossy() == "/dev/null" {
                     Vec::new()
@@ -829,7 +889,17 @@ fn build_diff_from_input_mode(
                         .context(format!("Failed to read: {}", new_path.display()))?
                 };
 
-                MultiFileDiff::from_file_pair_bytes(new_path.clone(), old_bytes, new_bytes)
+                let old_source =
+                    (old_path.to_string_lossy() != "/dev/null").then(|| old_path.clone());
+                let new_source =
+                    (new_path.to_string_lossy() != "/dev/null").then(|| new_path.clone());
+                MultiFileDiff::from_file_pair_with_sources(
+                    new_path.clone(),
+                    old_bytes,
+                    new_bytes,
+                    old_source,
+                    new_source,
+                )
             };
             (diff, None)
         }
@@ -880,8 +950,13 @@ fn build_diff_from_input_mode(
                 Vec::new()
             };
 
-            let diff =
-                MultiFileDiff::from_file_pair_bytes(rel_path.to_path_buf(), old_bytes, new_bytes);
+            let diff = MultiFileDiff::from_file_pair_with_sources(
+                rel_path.to_path_buf(),
+                old_bytes,
+                new_bytes,
+                None,
+                Some(abs_path),
+            );
             let branch = oyo_core::git::get_current_branch(&repo_root).ok();
             (diff, branch)
         }


### PR DESCRIPTION
Track source paths for file and directory diffs so o opens editable originals when they exist. Keep snapshot fallback for missing sources and revision content. For jj external dirs, infer the workspace root from the launching process on Linux.