### PR TITLE
feat(keybindings): add configurable keymaps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "keymap"
+version = "1.0.0-rc.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc6078e89b7d12ec47d8796161b5f4ae993cbaa3a5f2f92522abc284d512b39"
+dependencies = [
+ "crossterm",
+ "keymap_derive",
+ "keymap_parser",
+ "serde",
+]
+
+[[package]]
+name = "keymap_derive"
+version = "1.0.0-rc.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78cce206c65d68610eadbb87a168270aa776bc66997b9ada805de45be7473541"
+dependencies = [
+ "keymap_parser",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "keymap_parser"
+version = "1.0.0-rc.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7853d5e715f8d709403685739445829774d0561f70aed2a77b4545c398502ff5"
+dependencies = [
+ "serde",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,6 +921,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "flate2",
+ "keymap",
  "oyo-core",
  "ratatui",
  "regex",
@@ -1065,7 +1101,7 @@ dependencies = [
  "itertools 0.14.0",
  "kasuari",
  "lru",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
@@ -1097,7 +1133,7 @@ dependencies = [
  "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
- "strum",
+ "strum 0.27.2",
  "time",
  "unicode-segmentation",
  "unicode-width",
@@ -1361,14 +1397,32 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
 ]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 
 [[package]]
 name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ ignore = "0.4"
 # TUI
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 crossterm = "0.29"
+keymap = { version = "1.0.0-rc.6", features = ["crossterm"] }
 tui-textarea = "0.7"
 
 # Async

--- a/README.md
+++ b/README.md
@@ -373,6 +373,18 @@ open_at_line = true          # Used when args is omitted
 [comments.mentions]
 file_scope = "repo"         # "changed" | "repo" (git-aware via ls-files)
 finder = "auto"             # "auto" | "builtin" | "fzf"
+
+[keybindings.normal]
+# Omitted actions keep defaults. An empty array unbinds the action.
+step_down = ["j", "down"]
+step_up = ["k", "up"]
+goto_start = ["g g", "home"]
+toggle_help = ["?"]
+
+[keybindings.search]
+cancel = ["esc"]
+accept = ["enter"]
+clear = ["ctrl-u"]
 ```
 
 Example config:
@@ -421,6 +433,9 @@ autoplay = false
 [comments.mentions]
 file_scope = "repo"
 finder = "auto"
+
+[keybindings.normal]
+step_down = ["o"] # replaces the default j/down binding
 ```
 
 Config is loaded from (in priority order):

--- a/crates/oyo/Cargo.toml
+++ b/crates/oyo/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = { workspace = true }
 anyhow = { workspace = true }
 ratatui = { workspace = true }
 crossterm = { workspace = true, features = ["use-dev-tty"] }
+keymap = { workspace = true, features = ["crossterm"] }
 clap = { workspace = true }
 flate2 = { workspace = true }
 tokio = { workspace = true }

--- a/crates/oyo/src/app/mod.rs
+++ b/crates/oyo/src/app/mod.rs
@@ -6,6 +6,7 @@ use crate::config::{
     FileCountMode, FoldContextMode, HunkWrapMode, MentionFileScope, MentionFinder,
     ModifiedStepMode, ResolvedTheme, StepWrapMode, SyntaxMode,
 };
+use crate::keybindings::Keybindings;
 use crate::syntax::{SyntaxCache, SyntaxEngine};
 use crate::time_format::TimeFormatter;
 use oyo_core::{
@@ -81,6 +82,8 @@ pub struct App {
     files_visited: Vec<bool>,
     /// Whether to quit
     pub should_quit: bool,
+    /// Runtime keyboard bindings and sequence state
+    pub(crate) keybindings: Keybindings,
     /// Whether to open the commit picker dashboard
     pub open_dashboard: bool,
     /// Current animation phase
@@ -141,8 +144,6 @@ pub struct App {
     pub animation_duration: u64,
     /// Pending count for vim-style commands (e.g., 10j = scroll down 10 lines)
     pub pending_count: Option<usize>,
-    /// Pending "g" prefix for vim-style commands (e.g., gg)
-    pub pending_g_prefix: bool,
     /// True when at least one tracked file changed on disk since refresh
     pub files_changed_on_disk: bool,
     /// Last time we checked file mtimes
@@ -515,6 +516,7 @@ impl App {
             no_step_visited: vec![false; file_count],
             files_visited: vec![false; file_count],
             should_quit: false,
+            keybindings: Keybindings::default(),
             open_dashboard: false,
             animation_phase: AnimationPhase::Idle,
             animation_progress: 1.0,
@@ -545,7 +547,6 @@ impl App {
             topbar: true,
             animation_duration: 150,
             pending_count: None,
-            pending_g_prefix: false,
             files_changed_on_disk: false,
             last_fs_check: Instant::now(),
             file_disk_baseline: vec![FileDiskStamp::default(); file_count],

--- a/crates/oyo/src/config.rs
+++ b/crates/oyo/src/config.rs
@@ -59,12 +59,17 @@
 //! # command = "nvim"
 //! # args = ["+{line}", "{file}"]
 //! open_at_line = true
+//!
+//! [keybindings.normal]
+//! step_down = ["j", "down"]
+//! step_up = ["k", "up"]
+//! goto_start = ["g g", "home"]
 //! ```
 
 use crate::color::{self, AnimationGradient};
 use ratatui::style::Color;
 use serde::{de, Deserialize};
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -1370,6 +1375,60 @@ pub struct CommentsConfig {
     pub mentions: MentionConfig,
 }
 
+/// User keybinding overrides grouped by keybinding mode.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct KeybindingsConfig {
+    pub modes: BTreeMap<String, BTreeMap<String, Vec<String>>>,
+}
+
+impl<'de> Deserialize<'de> for KeybindingsConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = toml::Value::deserialize(deserializer)?;
+        let Some(table) = value.as_table() else {
+            eprintln!("Warning: Ignoring [keybindings]: expected a table");
+            return Ok(Self::default());
+        };
+        let mut modes = BTreeMap::new();
+        for (mode, mode_value) in table {
+            let Some(mode_table) = mode_value.as_table() else {
+                eprintln!("Warning: Ignoring [keybindings.{}]: expected a table", mode);
+                continue;
+            };
+            let mut actions = BTreeMap::new();
+            for (action, action_value) in mode_table {
+                let Some(keys) = action_value.as_array() else {
+                    eprintln!(
+                        "Warning: Ignoring keybinding '{}.{}': expected an array of strings",
+                        mode, action
+                    );
+                    continue;
+                };
+                let mut parsed_keys = Vec::new();
+                let mut valid = true;
+                for key in keys {
+                    let Some(key) = key.as_str() else {
+                        eprintln!(
+                            "Warning: Ignoring keybinding '{}.{}': expected an array of strings",
+                            mode, action
+                        );
+                        valid = false;
+                        break;
+                    };
+                    parsed_keys.push(key.to_string());
+                }
+                if valid {
+                    actions.insert(action.clone(), parsed_keys);
+                }
+            }
+            modes.insert(mode.clone(), actions);
+        }
+        Ok(Self { modes })
+    }
+}
+
 /// Root configuration
 #[derive(Debug, Deserialize, Default)]
 #[serde(default)]
@@ -1381,6 +1440,7 @@ pub struct Config {
     pub no_step: NoStepConfig,
     pub comments: CommentsConfig,
     pub editor: EditorConfig,
+    pub keybindings: KeybindingsConfig,
 }
 
 impl Config {

--- a/crates/oyo/src/dashboard.rs
+++ b/crates/oyo/src/dashboard.rs
@@ -1,6 +1,7 @@
 //! Git range picker dashboard for oy view
 
 use crate::config::ResolvedTheme;
+use crate::keybindings::{DashboardAction, Keybindings};
 use crate::time_format::TimeFormatter;
 use oyo_core::git::CommitEntry;
 use ratatui::{
@@ -52,7 +53,7 @@ struct DashboardEntry {
     kind: EntryKind,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Dashboard {
     repo_root: PathBuf,
     branch: Option<String>,
@@ -69,9 +70,10 @@ pub struct Dashboard {
     extent_marker: String,
     last_list_area: Rect,
     time_format: TimeFormatter,
+    keybindings: Keybindings,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct DashboardConfig {
     pub repo_root: PathBuf,
     pub branch: Option<String>,
@@ -82,6 +84,7 @@ pub struct DashboardConfig {
     pub primary_marker: String,
     pub extent_marker: String,
     pub time_format: TimeFormatter,
+    pub keybindings: Keybindings,
 }
 
 struct RenderLineContext<'a> {
@@ -141,11 +144,16 @@ impl Dashboard {
             extent_marker: config.extent_marker,
             last_list_area: Rect::default(),
             time_format: config.time_format,
+            keybindings: config.keybindings,
         }
     }
 
     pub fn filter_active(&self) -> bool {
         self.filter_active
+    }
+
+    pub(crate) fn keybindings_mut(&mut self) -> &mut Keybindings {
+        &mut self.keybindings
     }
 
     pub fn start_filter(&mut self) {
@@ -473,8 +481,12 @@ impl Dashboard {
                 Style::default().fg(self.theme.text),
             )));
         } else {
+            let hint = format!(
+                "{} to mark range start",
+                self.keybindings.dashboard_keys(DashboardAction::TogglePin)
+            );
             lines.push(Line::from(Span::styled(
-                "Space to mark range start",
+                hint,
                 Style::default()
                     .fg(self.theme.text_muted)
                     .add_modifier(Modifier::DIM),
@@ -497,7 +509,11 @@ impl Dashboard {
                 format!("> {}", self.filter)
             }
         } else if self.filter.is_empty() {
-            "\"/\" Filter".to_string()
+            format!(
+                "{} Filter",
+                self.keybindings
+                    .dashboard_keys(DashboardAction::StartFilter)
+            )
         } else {
             self.filter.clone()
         };
@@ -506,7 +522,12 @@ impl Dashboard {
         } else {
             Style::default().fg(self.theme.text_muted)
         };
-        let hint_text = "Enter open • Space pin • Esc quit";
+        let hint_text = format!(
+            "{} open • {} pin • {} quit",
+            self.keybindings.dashboard_keys(DashboardAction::Accept),
+            self.keybindings.dashboard_keys(DashboardAction::TogglePin),
+            self.keybindings.dashboard_keys(DashboardAction::Quit)
+        );
         let lines = vec![
             Line::raw(""),
             Line::from(Span::styled(
@@ -514,7 +535,7 @@ impl Dashboard {
                 filter_style,
             )),
             Line::from(Span::styled(
-                truncate_text(hint_text, area.width as usize),
+                truncate_text(&hint_text, area.width as usize),
                 Style::default()
                     .fg(self.theme.text_muted)
                     .add_modifier(Modifier::DIM),

--- a/crates/oyo/src/input.rs
+++ b/crates/oyo/src/input.rs
@@ -1,0 +1,668 @@
+use crate::app::{App, ViewMode};
+use crate::config;
+use crate::keybindings::{
+    Dispatch, FileFilterAction, HelpAction, LineInputAction, NormalAction, PickerAction,
+    ReviewEditorAction,
+};
+use anyhow::Result;
+use crossterm::{
+    event::{Event, KeyCode, KeyEvent, KeyModifiers},
+    terminal,
+};
+
+use super::{coalesce_key_repeats, open_current_file_in_editor, TuiTerminal};
+
+pub(crate) fn handle_app_key(
+    app: &mut App,
+    key: KeyEvent,
+    pending_event: &mut Option<Event>,
+    terminal: &mut TuiTerminal,
+    editor_config: &config::EditorConfig,
+) -> Result<()> {
+    if app.show_help {
+        handle_help_key(app, key);
+        return Ok(());
+    }
+
+    if app.review_editor_active() {
+        handle_review_editor_key(app, key);
+        return Ok(());
+    }
+
+    if app.command_palette_active() {
+        handle_command_palette_key(app, key);
+        return Ok(());
+    }
+
+    if app.file_search_active() {
+        handle_file_search_key(app, key);
+        return Ok(());
+    }
+
+    if app.file_filter_active {
+        handle_file_filter_key(app, key);
+        return Ok(());
+    }
+
+    if app.goto_active() {
+        handle_goto_key(app, key);
+        return Ok(());
+    }
+
+    if app.search_active() {
+        handle_search_key(app, key);
+        return Ok(());
+    }
+
+    handle_normal_key(app, key, pending_event, terminal, editor_config)
+}
+
+fn printable_char(key: KeyEvent) -> Option<char> {
+    match key.code {
+        KeyCode::Char(c)
+            if !key.modifiers.contains(KeyModifiers::CONTROL)
+                && !key.modifiers.contains(KeyModifiers::ALT) =>
+        {
+            Some(c)
+        }
+        _ => None,
+    }
+}
+
+fn handle_help_key(app: &mut App, key: KeyEvent) {
+    match app.keybindings.help(key) {
+        Dispatch::Matched(HelpAction::Close) => app.toggle_help(),
+        Dispatch::Matched(HelpAction::ScrollDown) => app.help_scroll_down(),
+        Dispatch::Matched(HelpAction::ScrollUp) => app.help_scroll_up(),
+        Dispatch::Pending | Dispatch::Unmatched => {}
+    }
+}
+
+fn handle_review_editor_key(app: &mut App, key: KeyEvent) {
+    match app.keybindings.review_editor(key) {
+        Dispatch::Matched(ReviewEditorAction::Cancel) => {
+            if !app.review_cancel_mention_picker() {
+                app.review_cancel_editor();
+            }
+        }
+        Dispatch::Matched(ReviewEditorAction::Save) => app.review_save_editor(),
+        Dispatch::Matched(ReviewEditorAction::InsertNewline) => {
+            if !app.review_accept_mention() {
+                app.review_insert_newline();
+            }
+        }
+        Dispatch::Matched(ReviewEditorAction::AcceptMention) => {
+            let _ = app.review_accept_mention();
+        }
+        Dispatch::Matched(ReviewEditorAction::Backspace) => app.review_backspace(),
+        Dispatch::Matched(ReviewEditorAction::Delete) => app.review_delete(),
+        Dispatch::Matched(ReviewEditorAction::Left) => app.review_move_left(),
+        Dispatch::Matched(ReviewEditorAction::Right) => app.review_move_right(),
+        Dispatch::Matched(ReviewEditorAction::Up) => {
+            if app.review_mention_picker_active() {
+                app.review_mention_move_selection(-1);
+            } else {
+                app.review_move_up();
+            }
+        }
+        Dispatch::Matched(ReviewEditorAction::Down) => {
+            if app.review_mention_picker_active() {
+                app.review_mention_move_selection(1);
+            } else {
+                app.review_move_down();
+            }
+        }
+        Dispatch::Matched(ReviewEditorAction::Home) => app.review_move_home(),
+        Dispatch::Matched(ReviewEditorAction::End) => app.review_move_end(),
+        Dispatch::Matched(ReviewEditorAction::Clear) => app.review_clear_editor_text(),
+        Dispatch::Matched(ReviewEditorAction::MentionNext) => {
+            if app.review_mention_picker_active() {
+                app.review_mention_move_selection(1);
+            }
+        }
+        Dispatch::Matched(ReviewEditorAction::MentionPrev) => {
+            if app.review_mention_picker_active() {
+                app.review_mention_move_selection(-1);
+            }
+        }
+        Dispatch::Pending => {}
+        Dispatch::Unmatched => {
+            if let Some(c) = printable_char(key) {
+                app.review_insert_char(c);
+            }
+        }
+    }
+}
+
+fn handle_command_palette_key(app: &mut App, key: KeyEvent) {
+    match app.keybindings.command_palette(key) {
+        Dispatch::Matched(PickerAction::Cancel) => app.stop_command_palette(),
+        Dispatch::Matched(PickerAction::Accept) => app.apply_command_palette_selection(),
+        Dispatch::Matched(PickerAction::Backspace) => {
+            if app.command_palette_query().is_empty() {
+                app.stop_command_palette();
+            } else {
+                app.pop_command_palette_char();
+            }
+        }
+        Dispatch::Matched(PickerAction::Clear) => app.clear_command_palette_text(),
+        Dispatch::Matched(PickerAction::SelectNext) => app.move_command_palette_selection(1),
+        Dispatch::Matched(PickerAction::SelectPrev) => app.move_command_palette_selection(-1),
+        Dispatch::Pending => {}
+        Dispatch::Unmatched => {
+            if let Some(c) = printable_char(key) {
+                app.push_command_palette_char(c);
+            }
+        }
+    }
+}
+
+fn handle_file_search_key(app: &mut App, key: KeyEvent) {
+    match app.keybindings.file_search(key) {
+        Dispatch::Matched(PickerAction::Cancel) => app.stop_file_search(),
+        Dispatch::Matched(PickerAction::Accept) => app.apply_file_search_selection(),
+        Dispatch::Matched(PickerAction::Backspace) => {
+            if app.file_search_query().is_empty() {
+                app.stop_file_search();
+            } else {
+                app.pop_file_search_char();
+            }
+        }
+        Dispatch::Matched(PickerAction::Clear) => app.clear_file_search_text(),
+        Dispatch::Matched(PickerAction::SelectNext) => app.move_file_search_selection(1),
+        Dispatch::Matched(PickerAction::SelectPrev) => app.move_file_search_selection(-1),
+        Dispatch::Pending => {}
+        Dispatch::Unmatched => {
+            if let Some(c) = printable_char(key) {
+                app.push_file_search_char(c);
+            }
+        }
+    }
+}
+
+fn handle_file_filter_key(app: &mut App, key: KeyEvent) {
+    match app.keybindings.file_filter(key) {
+        Dispatch::Matched(FileFilterAction::Close) => app.stop_file_filter(),
+        Dispatch::Matched(FileFilterAction::Backspace) => app.pop_file_filter_char(),
+        Dispatch::Matched(FileFilterAction::Clear) => app.clear_file_filter(),
+        Dispatch::Pending => {}
+        Dispatch::Unmatched => {
+            if let Some(c) = printable_char(key) {
+                app.push_file_filter_char(c);
+            }
+        }
+    }
+}
+
+fn handle_goto_key(app: &mut App, key: KeyEvent) {
+    match app.keybindings.goto(key) {
+        Dispatch::Matched(LineInputAction::Cancel) => app.clear_goto(),
+        Dispatch::Matched(LineInputAction::Accept) => {
+            app.apply_goto();
+            app.clear_goto();
+        }
+        Dispatch::Matched(LineInputAction::Backspace) => {
+            if app.goto_query().is_empty() {
+                app.clear_goto();
+            } else {
+                app.pop_goto_char();
+            }
+        }
+        Dispatch::Matched(LineInputAction::Clear) => app.clear_goto_text(),
+        Dispatch::Pending => {}
+        Dispatch::Unmatched => {
+            if let Some(c) = printable_char(key) {
+                app.push_goto_char(c);
+            }
+        }
+    }
+}
+
+fn handle_search_key(app: &mut App, key: KeyEvent) {
+    match app.keybindings.search(key) {
+        Dispatch::Matched(LineInputAction::Cancel) => app.clear_search(),
+        Dispatch::Matched(LineInputAction::Accept) => {
+            app.stop_search();
+            app.search_next();
+        }
+        Dispatch::Matched(LineInputAction::Backspace) => {
+            if app.search_query().is_empty() {
+                app.clear_search();
+            } else {
+                app.pop_search_char();
+            }
+        }
+        Dispatch::Matched(LineInputAction::Clear) => app.clear_search_text(),
+        Dispatch::Pending => {}
+        Dispatch::Unmatched => {
+            if let Some(c) = printable_char(key) {
+                app.push_search_char(c);
+            }
+        }
+    }
+}
+
+fn repeat_count(
+    app: &mut App,
+    key: KeyEvent,
+    pending_event: &mut Option<Event>,
+    coalesce: bool,
+) -> Result<usize> {
+    if app.pending_count.is_some() {
+        Ok(app.take_count())
+    } else if coalesce {
+        Ok(coalesce_key_repeats(key, pending_event)?)
+    } else {
+        Ok(app.take_count())
+    }
+}
+
+fn handle_normal_key(
+    app: &mut App,
+    key: KeyEvent,
+    pending_event: &mut Option<Event>,
+    terminal: &mut TuiTerminal,
+    editor_config: &config::EditorConfig,
+) -> Result<()> {
+    if matches!(key.code, KeyCode::Char(c @ '0'..='9') if c != '0' || app.pending_count.is_some()) {
+        if let KeyCode::Char(c) = key.code {
+            app.keybindings.clear_sequence();
+            app.push_count_digit(c as u8 - b'0');
+        }
+        return Ok(());
+    }
+
+    match app.keybindings.normal(key) {
+        Dispatch::Matched(action) => {
+            dispatch_normal_action(app, action, key, pending_event, terminal, editor_config)?;
+        }
+        Dispatch::Pending => {}
+        Dispatch::Unmatched => app.reset_count(),
+    }
+    Ok(())
+}
+
+fn dispatch_normal_action(
+    app: &mut App,
+    action: NormalAction,
+    key: KeyEvent,
+    pending_event: &mut Option<Event>,
+    terminal: &mut TuiTerminal,
+    editor_config: &config::EditorConfig,
+) -> Result<()> {
+    match action {
+        NormalAction::Quit => {
+            app.reset_count();
+            if app.show_path_popup {
+                app.show_path_popup = false;
+            } else {
+                app.submit_review_and_quit();
+            }
+        }
+        NormalAction::StepDown => {
+            let count = repeat_count(app, key, pending_event, true)?;
+            for _ in 0..count {
+                if app.file_list_focused {
+                    app.next_file();
+                } else if app.stepping {
+                    app.next_step();
+                } else {
+                    app.scroll_down();
+                }
+            }
+        }
+        NormalAction::StepUp => {
+            let count = repeat_count(app, key, pending_event, true)?;
+            for _ in 0..count {
+                if app.file_list_focused {
+                    app.prev_file();
+                } else if app.stepping {
+                    app.prev_step();
+                } else {
+                    app.scroll_up();
+                }
+            }
+        }
+        NormalAction::NextHunk => {
+            let count = repeat_count(app, key, pending_event, true)?;
+            app.defer_view_build_for_jump();
+            for _ in 0..count {
+                if app.stepping {
+                    app.next_hunk();
+                } else {
+                    app.next_hunk_scroll();
+                }
+            }
+        }
+        NormalAction::PrevHunk => {
+            let count = repeat_count(app, key, pending_event, true)?;
+            app.defer_view_build_for_jump();
+            for _ in 0..count {
+                if app.stepping {
+                    app.prev_hunk();
+                } else {
+                    app.prev_hunk_scroll();
+                }
+            }
+        }
+        NormalAction::HunkStart => {
+            app.reset_count();
+            app.defer_view_build_for_jump();
+            if app.stepping {
+                app.goto_hunk_start();
+            } else {
+                app.goto_hunk_start_scroll();
+            }
+        }
+        NormalAction::HunkEnd => {
+            app.reset_count();
+            app.defer_view_build_for_jump();
+            if app.stepping {
+                app.goto_hunk_end();
+            } else {
+                app.goto_hunk_end_scroll();
+            }
+        }
+        NormalAction::BlameHint => {
+            app.reset_count();
+            if app.blame_enabled {
+                app.trigger_blame_hint();
+            }
+        }
+        NormalAction::TogglePeekChange => {
+            app.reset_count();
+            if app.stepping {
+                app.toggle_peek_old_change();
+            }
+        }
+        NormalAction::TogglePeekHunk => {
+            app.reset_count();
+            if app.stepping {
+                app.toggle_peek_old_hunk();
+            }
+        }
+        NormalAction::YankChange => {
+            app.reset_count();
+            app.yank_current_change();
+        }
+        NormalAction::YankHunk => {
+            app.reset_count();
+            app.yank_current_hunk();
+        }
+        NormalAction::YankChangePatch => {
+            app.reset_count();
+            app.yank_current_change_patch();
+        }
+        NormalAction::YankHunkPatch => {
+            app.reset_count();
+            app.yank_current_hunk_patch();
+        }
+        NormalAction::TogglePathPopup => {
+            app.reset_count();
+            app.toggle_path_popup();
+        }
+        NormalAction::OpenEditor => {
+            app.reset_count();
+            open_current_file_in_editor(terminal, app, editor_config)?;
+        }
+        NormalAction::GotoStart => {
+            app.reset_count();
+            app.defer_view_build_for_jump();
+            app.goto_start();
+        }
+        NormalAction::GotoEnd => {
+            app.reset_count();
+            app.defer_view_build_for_jump();
+            app.goto_end();
+        }
+        NormalAction::FirstStep => {
+            app.reset_count();
+            app.defer_view_build_for_jump();
+            if app.stepping {
+                app.goto_first_step();
+            } else {
+                app.goto_first_hunk_scroll();
+            }
+        }
+        NormalAction::LastStep => {
+            app.reset_count();
+            app.defer_view_build_for_jump();
+            if app.stepping {
+                app.goto_last_step();
+            } else {
+                app.goto_last_hunk_scroll();
+            }
+        }
+        NormalAction::PrevFile => {
+            let count = repeat_count(app, key, pending_event, false)?;
+            for _ in 0..count {
+                app.prev_file();
+            }
+        }
+        NormalAction::NextFile => {
+            let count = repeat_count(app, key, pending_event, false)?;
+            for _ in 0..count {
+                app.next_file();
+            }
+        }
+        NormalAction::ToggleAutoplay => {
+            app.reset_count();
+            if app.stepping {
+                app.toggle_autoplay();
+            }
+        }
+        NormalAction::ToggleAutoplayReverse => {
+            app.reset_count();
+            if app.stepping {
+                app.toggle_autoplay_reverse();
+            }
+        }
+        NormalAction::ToggleViewMode => {
+            app.reset_count();
+            app.toggle_view_mode();
+        }
+        NormalAction::ToggleViewModeReverse => {
+            app.reset_count();
+            app.toggle_view_mode_reverse();
+        }
+        NormalAction::ScrollUp => {
+            let count = repeat_count(app, key, pending_event, false)?;
+            for _ in 0..count {
+                app.scroll_up();
+            }
+        }
+        NormalAction::ScrollDown => {
+            let count = repeat_count(app, key, pending_event, false)?;
+            for _ in 0..count {
+                app.scroll_down();
+            }
+        }
+        NormalAction::HalfPageUp => {
+            app.reset_count();
+            if let Ok((_, rows)) = terminal::size() {
+                app.scroll_half_page_up(rows.saturating_sub(6) as usize);
+            }
+        }
+        NormalAction::HalfPageDown => {
+            app.reset_count();
+            if let Ok((_, rows)) = terminal::size() {
+                app.scroll_half_page_down(rows.saturating_sub(6) as usize);
+            }
+        }
+        NormalAction::ToggleFileListFocus => {
+            app.reset_count();
+            if app.is_multi_file() {
+                app.file_list_focused = !app.file_list_focused;
+                if !app.file_list_focused {
+                    app.stop_file_filter();
+                }
+            }
+        }
+        NormalAction::IncreaseSpeed => {
+            app.reset_count();
+            if app.is_multi_file() && app.file_list_focused {
+                if let Ok((cols, _)) = terminal::size() {
+                    app.resize_file_panel(2, cols);
+                }
+            } else {
+                app.increase_speed();
+            }
+        }
+        NormalAction::DecreaseSpeed => {
+            app.reset_count();
+            if app.is_multi_file() && app.file_list_focused {
+                if let Ok((cols, _)) = terminal::size() {
+                    app.resize_file_panel(-2, cols);
+                }
+            } else {
+                app.decrease_speed();
+            }
+        }
+        NormalAction::ToggleAnimation => {
+            app.reset_count();
+            app.toggle_animation();
+        }
+        NormalAction::ToggleLineWrap => {
+            app.reset_count();
+            app.toggle_line_wrap();
+        }
+        NormalAction::ToggleSyntax => {
+            app.reset_count();
+            app.toggle_syntax();
+        }
+        NormalAction::ToggleEvoSyntax => {
+            app.reset_count();
+            if app.view_mode == ViewMode::Evolution {
+                app.toggle_evo_syntax();
+            }
+        }
+        NormalAction::ToggleStepping => {
+            app.reset_count();
+            app.toggle_stepping();
+        }
+        NormalAction::ToggleStrikethrough => {
+            app.reset_count();
+            app.toggle_strikethrough_deletions();
+        }
+        NormalAction::ScrollLeft => {
+            let count = repeat_count(app, key, pending_event, false)?;
+            for _ in 0..count {
+                app.scroll_left();
+            }
+        }
+        NormalAction::ScrollRight => {
+            let count = repeat_count(app, key, pending_event, false)?;
+            for _ in 0..count {
+                app.scroll_right();
+            }
+        }
+        NormalAction::LineStart => {
+            app.reset_count();
+            app.scroll_to_line_start();
+        }
+        NormalAction::LineEnd => {
+            app.reset_count();
+            app.scroll_to_line_end();
+        }
+        NormalAction::CenterActive => {
+            app.reset_count();
+            if let Ok((_, rows)) = terminal::size() {
+                app.center_on_active(rows.saturating_sub(4) as usize);
+            }
+        }
+        NormalAction::ToggleZen => {
+            app.reset_count();
+            app.toggle_zen();
+        }
+        NormalAction::ReplayStep => app.replay_step(),
+        NormalAction::Refresh => {
+            app.reset_count();
+            if app.multi_diff.is_git_mode() {
+                app.refresh_all_files();
+            } else {
+                app.refresh_current_file();
+            }
+        }
+        NormalAction::ToggleFilePanel => {
+            app.reset_count();
+            if app.is_multi_file() {
+                app.toggle_file_panel();
+            }
+        }
+        NormalAction::ToggleFoldContext => {
+            app.reset_count();
+            app.toggle_fold_context();
+        }
+        NormalAction::OpenSearchOrFileFilter => {
+            app.reset_count();
+            if app.file_list_focused {
+                app.start_file_filter();
+            } else {
+                app.start_search();
+            }
+        }
+        NormalAction::OpenGoto => {
+            app.reset_count();
+            if !app.file_list_focused {
+                app.start_goto();
+            }
+        }
+        NormalAction::SearchNext => {
+            app.reset_count();
+            app.search_next();
+        }
+        NormalAction::SearchPrev => {
+            app.reset_count();
+            app.search_prev();
+        }
+        NormalAction::NextConflict => {
+            app.reset_count();
+            app.next_conflict();
+        }
+        NormalAction::PrevConflict => {
+            app.reset_count();
+            app.prev_conflict();
+        }
+        NormalAction::LineComment => {
+            app.reset_count();
+            app.start_line_comment();
+        }
+        NormalAction::HunkComment => {
+            app.reset_count();
+            app.start_hunk_comment();
+        }
+        NormalAction::ClearComments => {
+            app.reset_count();
+            app.clear_all_review_comments();
+        }
+        NormalAction::RemoveLineComment => {
+            app.reset_count();
+            app.remove_line_comment_at_cursor();
+        }
+        NormalAction::RemoveHunkComment => {
+            app.reset_count();
+            app.remove_hunk_comment_at_cursor();
+        }
+        NormalAction::ToggleHelp => {
+            app.reset_count();
+            app.toggle_help();
+        }
+        NormalAction::OpenCommandPalette => {
+            app.reset_count();
+            if app.command_palette_active() {
+                app.stop_command_palette();
+            } else {
+                app.start_command_palette();
+            }
+        }
+        NormalAction::OpenFileSearch => {
+            app.reset_count();
+            if app.file_search_active() {
+                app.stop_file_search();
+            } else {
+                app.start_file_search();
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/oyo/src/keybindings.rs
+++ b/crates/oyo/src/keybindings.rs
@@ -1,0 +1,891 @@
+use crate::config::KeybindingsConfig;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use keymap::{parser::parse_seq, Config, Item, KeyMap, Matcher, ToKeyMap};
+use std::collections::{BTreeMap, HashSet};
+use std::hash::Hash;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum KeybindingMode {
+    Normal,
+    Help,
+    ReviewEditor,
+    CommandPalette,
+    FileSearch,
+    FileFilter,
+    Goto,
+    Search,
+    Dashboard,
+    DashboardFilter,
+}
+
+impl KeybindingMode {
+    fn id(self) -> &'static str {
+        match self {
+            Self::Normal => "normal",
+            Self::Help => "help",
+            Self::ReviewEditor => "review_editor",
+            Self::CommandPalette => "command_palette",
+            Self::FileSearch => "file_search",
+            Self::FileFilter => "file_filter",
+            Self::Goto => "goto",
+            Self::Search => "search",
+            Self::Dashboard => "dashboard",
+            Self::DashboardFilter => "dashboard_filter",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum NormalAction {
+    Quit,
+    StepDown,
+    StepUp,
+    NextHunk,
+    PrevHunk,
+    HunkStart,
+    HunkEnd,
+    BlameHint,
+    TogglePeekChange,
+    TogglePeekHunk,
+    YankChange,
+    YankHunk,
+    YankChangePatch,
+    YankHunkPatch,
+    TogglePathPopup,
+    OpenEditor,
+    GotoStart,
+    GotoEnd,
+    FirstStep,
+    LastStep,
+    PrevFile,
+    NextFile,
+    ToggleAutoplay,
+    ToggleAutoplayReverse,
+    ToggleViewMode,
+    ToggleViewModeReverse,
+    ScrollUp,
+    ScrollDown,
+    HalfPageUp,
+    HalfPageDown,
+    ToggleFileListFocus,
+    IncreaseSpeed,
+    DecreaseSpeed,
+    ToggleAnimation,
+    ToggleLineWrap,
+    ToggleSyntax,
+    ToggleEvoSyntax,
+    ToggleStepping,
+    ToggleStrikethrough,
+    ScrollLeft,
+    ScrollRight,
+    LineStart,
+    LineEnd,
+    CenterActive,
+    ToggleZen,
+    ReplayStep,
+    Refresh,
+    ToggleFilePanel,
+    ToggleFoldContext,
+    OpenSearchOrFileFilter,
+    OpenGoto,
+    SearchNext,
+    SearchPrev,
+    NextConflict,
+    PrevConflict,
+    LineComment,
+    HunkComment,
+    ClearComments,
+    RemoveLineComment,
+    RemoveHunkComment,
+    ToggleHelp,
+    OpenCommandPalette,
+    OpenFileSearch,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum HelpAction {
+    Close,
+    ScrollDown,
+    ScrollUp,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum ReviewEditorAction {
+    Cancel,
+    Save,
+    InsertNewline,
+    AcceptMention,
+    Backspace,
+    Delete,
+    Left,
+    Right,
+    Up,
+    Down,
+    Home,
+    End,
+    Clear,
+    MentionNext,
+    MentionPrev,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum PickerAction {
+    Cancel,
+    Accept,
+    Backspace,
+    Clear,
+    SelectNext,
+    SelectPrev,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum LineInputAction {
+    Cancel,
+    Accept,
+    Backspace,
+    Clear,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum FileFilterAction {
+    Close,
+    Backspace,
+    Clear,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum DashboardAction {
+    Quit,
+    StartFilter,
+    ClearPin,
+    TogglePin,
+    Accept,
+    SelectNext,
+    SelectPrev,
+    PageDown,
+    PageUp,
+    SelectFirst,
+    SelectLast,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum DashboardFilterAction {
+    Cancel,
+    Accept,
+    Clear,
+    Backspace,
+    SelectNext,
+    SelectPrev,
+    PageDown,
+    PageUp,
+    SelectFirst,
+    SelectLast,
+}
+
+pub(crate) trait BindingAction: Copy + Eq + Hash {
+    fn id(self) -> &'static str;
+    fn description(self) -> &'static str;
+    fn defaults(self) -> &'static [&'static str];
+    fn all() -> &'static [Self];
+}
+
+macro_rules! binding_action {
+    ($ty:ty, [$($variant:ident => ($id:literal, $desc:literal, [$($key:literal),* $(,)?])),* $(,)?]) => {
+        impl BindingAction for $ty {
+            fn id(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $id,)*
+                }
+            }
+
+            fn description(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $desc,)*
+                }
+            }
+
+            fn defaults(self) -> &'static [&'static str] {
+                match self {
+                    $(Self::$variant => &[$($key),*],)*
+                }
+            }
+
+            fn all() -> &'static [Self] {
+                &[$(Self::$variant),*]
+            }
+        }
+    };
+}
+
+binding_action!(NormalAction, [
+    Quit => ("quit", "Quit (prints comments if any)", ["q", "esc"]),
+    StepDown => ("step_down", "Step forward", ["j", "down"]),
+    StepUp => ("step_up", "Step backward", ["k", "up"]),
+    NextHunk => ("next_hunk", "Next hunk", ["l", "right"]),
+    PrevHunk => ("prev_hunk", "Previous hunk", ["h", "left"]),
+    HunkStart => ("hunk_start", "Hunk begin", ["b"]),
+    HunkEnd => ("hunk_end", "Hunk end", ["e"]),
+    BlameHint => ("blame_hint", "Blame current step", ["g b"]),
+    TogglePeekChange => ("toggle_peek_change", "Peek change", ["p"]),
+    TogglePeekHunk => ("toggle_peek_hunk", "Peek old hunk", ["P"]),
+    YankChange => ("yank_change", "Yank line", ["y"]),
+    YankHunk => ("yank_hunk", "Yank hunk", ["Y"]),
+    YankChangePatch => ("yank_change_patch", "Copy line patch", ["g y"]),
+    YankHunkPatch => ("yank_hunk_patch", "Copy hunk patch", ["g Y"]),
+    TogglePathPopup => ("toggle_path_popup", "Show full file path", ["ctrl-g"]),
+    OpenEditor => ("open_editor", "Open file in editor", ["o", "ctrl-e"]),
+    GotoStart => ("goto_start", "Go to start", ["g g", "home"]),
+    GotoEnd => ("goto_end", "Go to end", ["G", "end"]),
+    FirstStep => ("first_step", "First step (or hunk in no-step)", ["<"]),
+    LastStep => ("last_step", "Last step (or hunk in no-step)", [">"]),
+    PrevFile => ("prev_file", "Previous file", ["["]),
+    NextFile => ("next_file", "Next file", ["]"]),
+    ToggleAutoplay => ("toggle_autoplay", "Autoplay forward", ["space"]),
+    ToggleAutoplayReverse => ("toggle_autoplay_reverse", "Autoplay reverse", ["B"]),
+    ToggleViewMode => ("toggle_view_mode", "Cycle view mode", ["tab"]),
+    ToggleViewModeReverse => ("toggle_view_mode_reverse", "Cycle view mode reverse", ["backtab"]),
+    ScrollUp => ("scroll_up", "Scroll up", ["K"]),
+    ScrollDown => ("scroll_down", "Scroll down", ["J"]),
+    HalfPageUp => ("half_page_up", "Scroll half-page up", ["ctrl-u"]),
+    HalfPageDown => ("half_page_down", "Scroll half-page down", ["ctrl-d"]),
+    ToggleFileListFocus => ("toggle_file_list_focus", "Focus file list", ["enter", "ctrl-a"]),
+    IncreaseSpeed => ("increase_speed", "Increase speed", ["+", "="]),
+    DecreaseSpeed => ("decrease_speed", "Decrease speed", ["-"]),
+    ToggleAnimation => ("toggle_animation", "Toggle animation", ["a"]),
+    ToggleLineWrap => ("toggle_line_wrap", "Toggle line wrap", ["w"]),
+    ToggleSyntax => ("toggle_syntax", "Toggle syntax highlight", ["t"]),
+    ToggleEvoSyntax => ("toggle_evo_syntax", "Toggle evo syntax", ["E"]),
+    ToggleStepping => ("toggle_stepping", "Toggle stepping", ["s"]),
+    ToggleStrikethrough => ("toggle_strikethrough", "Toggle strikethrough", ["S"]),
+    ScrollLeft => ("scroll_left", "Scroll left", ["H"]),
+    ScrollRight => ("scroll_right", "Scroll right", ["L"]),
+    LineStart => ("line_start", "Scroll to line start", ["0"]),
+    LineEnd => ("line_end", "Scroll to line end", ["$"]),
+    CenterActive => ("center_active", "Center on active", ["z"]),
+    ToggleZen => ("toggle_zen", "Zen mode", ["Z"]),
+    ReplayStep => ("replay_step", "Replay last step", ["r"]),
+    Refresh => ("refresh", "Refresh files", ["R"]),
+    ToggleFilePanel => ("toggle_file_panel", "Toggle file panel", ["ctrl-f"]),
+    ToggleFoldContext => ("toggle_fold_context", "Toggle context folding", ["f"]),
+    OpenSearchOrFileFilter => ("open_search_or_file_filter", "Search or filter files", ["/"]),
+    OpenGoto => ("open_goto", "Go to line/hunk/step", [":"]),
+    SearchNext => ("search_next", "Next match", ["n"]),
+    SearchPrev => ("search_prev", "Previous match", ["N"]),
+    NextConflict => ("next_conflict", "Next conflict", ["c"]),
+    PrevConflict => ("prev_conflict", "Previous conflict", ["C"]),
+    LineComment => ("line_comment", "Add/update line comment", ["m"]),
+    HunkComment => ("hunk_comment", "Add/update hunk comment", ["M"]),
+    ClearComments => ("clear_comments", "Clear all comments", ["ctrl-x"]),
+    RemoveLineComment => ("remove_line_comment", "Remove line comment", ["x"]),
+    RemoveHunkComment => ("remove_hunk_comment", "Remove hunk comment", ["X"]),
+    ToggleHelp => ("toggle_help", "Toggle help", ["?"]),
+    OpenCommandPalette => ("open_command_palette", "Command palette", ["ctrl-p"]),
+    OpenFileSearch => ("open_file_search", "Quick file search", ["ctrl-shift-p"]),
+]);
+
+binding_action!(HelpAction, [
+    Close => ("close", "Close help", ["esc", "q", "?"]),
+    ScrollDown => ("scroll_down", "Scroll down", ["j", "down"]),
+    ScrollUp => ("scroll_up", "Scroll up", ["k", "up"]),
+]);
+
+binding_action!(ReviewEditorAction, [
+    Cancel => ("cancel", "Cancel editor", ["esc"]),
+    Save => ("save", "Save comment", ["ctrl-enter"]),
+    InsertNewline => ("insert_newline", "Insert newline", ["enter"]),
+    AcceptMention => ("accept_mention", "Accept mention", ["tab"]),
+    Backspace => ("backspace", "Backspace", ["backspace"]),
+    Delete => ("delete", "Delete", ["delete"]),
+    Left => ("left", "Move left", ["left"]),
+    Right => ("right", "Move right", ["right"]),
+    Up => ("up", "Move up", ["up"]),
+    Down => ("down", "Move down", ["down"]),
+    Home => ("home", "Move to line start", ["home"]),
+    End => ("end", "Move to line end", ["end"]),
+    Clear => ("clear", "Clear text", ["ctrl-u"]),
+    MentionNext => ("mention_next", "Next mention candidate", ["ctrl-n"]),
+    MentionPrev => ("mention_prev", "Previous mention candidate", ["ctrl-p"]),
+]);
+
+binding_action!(PickerAction, [
+    Cancel => ("cancel", "Cancel", ["esc"]),
+    Accept => ("accept", "Accept", ["enter"]),
+    Backspace => ("backspace", "Backspace", ["backspace"]),
+    Clear => ("clear", "Clear query", ["ctrl-u"]),
+    SelectNext => ("select_next", "Select next", ["down"]),
+    SelectPrev => ("select_prev", "Select previous", ["up"]),
+]);
+
+binding_action!(LineInputAction, [
+    Cancel => ("cancel", "Cancel", ["esc"]),
+    Accept => ("accept", "Accept", ["enter"]),
+    Backspace => ("backspace", "Backspace", ["backspace"]),
+    Clear => ("clear", "Clear query", ["ctrl-u"]),
+]);
+
+binding_action!(FileFilterAction, [
+    Close => ("close", "Close filter", ["esc", "enter"]),
+    Backspace => ("backspace", "Backspace", ["backspace"]),
+    Clear => ("clear", "Clear filter", ["ctrl-u"]),
+]);
+
+binding_action!(DashboardAction, [
+    Quit => ("quit", "Quit dashboard", ["esc", "q"]),
+    StartFilter => ("start_filter", "Filter commits", ["/"]),
+    ClearPin => ("clear_pin", "Clear pinned range start", ["r"]),
+    TogglePin => ("toggle_pin", "Mark range start", ["space"]),
+    Accept => ("accept", "Open selection", ["enter"]),
+    SelectNext => ("select_next", "Select next", ["j", "down"]),
+    SelectPrev => ("select_prev", "Select previous", ["k", "up"]),
+    PageDown => ("page_down", "Page down", ["pagedown"]),
+    PageUp => ("page_up", "Page up", ["pageup"]),
+    SelectFirst => ("select_first", "Select first", ["g", "home"]),
+    SelectLast => ("select_last", "Select last", ["G", "end"]),
+]);
+
+binding_action!(DashboardFilterAction, [
+    Cancel => ("cancel", "Cancel filter", ["esc"]),
+    Accept => ("accept", "Open selection", ["enter"]),
+    Clear => ("clear", "Clear filter", ["ctrl-u"]),
+    Backspace => ("backspace", "Backspace", ["backspace"]),
+    SelectNext => ("select_next", "Select next", ["j", "down"]),
+    SelectPrev => ("select_prev", "Select previous", ["k", "up"]),
+    PageDown => ("page_down", "Page down", ["pagedown"]),
+    PageUp => ("page_up", "Page up", ["pageup"]),
+    SelectFirst => ("select_first", "Select first", ["g", "home"]),
+    SelectLast => ("select_last", "Select last", ["G", "end"]),
+]);
+
+#[derive(Debug)]
+pub(crate) struct Keybindings {
+    normal: ModeBindings<NormalAction>,
+    help: ModeBindings<HelpAction>,
+    review_editor: ModeBindings<ReviewEditorAction>,
+    command_palette: ModeBindings<PickerAction>,
+    file_search: ModeBindings<PickerAction>,
+    file_filter: ModeBindings<FileFilterAction>,
+    goto: ModeBindings<LineInputAction>,
+    search: ModeBindings<LineInputAction>,
+    dashboard: ModeBindings<DashboardAction>,
+    dashboard_filter: ModeBindings<DashboardFilterAction>,
+    active_sequence_mode: Option<KeybindingMode>,
+}
+
+#[derive(Debug)]
+struct ModeBindings<A> {
+    mode: KeybindingMode,
+    config: Config<A>,
+    effective: BTreeMap<&'static str, Vec<String>>,
+    prefix_matcher: Matcher<()>,
+    buffer: Vec<KeyEvent>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Dispatch<A> {
+    Matched(A),
+    Pending,
+    Unmatched,
+}
+
+impl Default for Keybindings {
+    fn default() -> Self {
+        Self::from_config(&KeybindingsConfig::default())
+    }
+}
+
+impl Keybindings {
+    pub(crate) fn from_config(config: &KeybindingsConfig) -> Self {
+        let mut warnings = Vec::new();
+        Self::from_config_with_warnings(config, &mut warnings)
+    }
+
+    pub(crate) fn from_config_with_warnings(
+        config: &KeybindingsConfig,
+        warnings: &mut Vec<String>,
+    ) -> Self {
+        warn_unknown_modes(config, warnings);
+        Self {
+            normal: ModeBindings::build(KeybindingMode::Normal, config, warnings),
+            help: ModeBindings::build(KeybindingMode::Help, config, warnings),
+            review_editor: ModeBindings::build(KeybindingMode::ReviewEditor, config, warnings),
+            command_palette: ModeBindings::build(KeybindingMode::CommandPalette, config, warnings),
+            file_search: ModeBindings::build(KeybindingMode::FileSearch, config, warnings),
+            file_filter: ModeBindings::build(KeybindingMode::FileFilter, config, warnings),
+            goto: ModeBindings::build(KeybindingMode::Goto, config, warnings),
+            search: ModeBindings::build(KeybindingMode::Search, config, warnings),
+            dashboard: ModeBindings::build(KeybindingMode::Dashboard, config, warnings),
+            dashboard_filter: ModeBindings::build(
+                KeybindingMode::DashboardFilter,
+                config,
+                warnings,
+            ),
+            active_sequence_mode: None,
+        }
+    }
+
+    pub(crate) fn clear_sequence(&mut self) {
+        match self.active_sequence_mode.take() {
+            Some(KeybindingMode::Normal) => self.normal.clear_sequence(),
+            Some(KeybindingMode::Help) => self.help.clear_sequence(),
+            Some(KeybindingMode::ReviewEditor) => self.review_editor.clear_sequence(),
+            Some(KeybindingMode::CommandPalette) => self.command_palette.clear_sequence(),
+            Some(KeybindingMode::FileSearch) => self.file_search.clear_sequence(),
+            Some(KeybindingMode::FileFilter) => self.file_filter.clear_sequence(),
+            Some(KeybindingMode::Goto) => self.goto.clear_sequence(),
+            Some(KeybindingMode::Search) => self.search.clear_sequence(),
+            Some(KeybindingMode::Dashboard) => self.dashboard.clear_sequence(),
+            Some(KeybindingMode::DashboardFilter) => self.dashboard_filter.clear_sequence(),
+            None => {}
+        }
+    }
+
+    pub(crate) fn normal(&mut self, key: KeyEvent) -> Dispatch<NormalAction> {
+        self.prepare_mode(KeybindingMode::Normal);
+        dispatch_mode(&mut self.active_sequence_mode, &mut self.normal, key)
+    }
+
+    pub(crate) fn help(&mut self, key: KeyEvent) -> Dispatch<HelpAction> {
+        self.prepare_mode(KeybindingMode::Help);
+        dispatch_mode(&mut self.active_sequence_mode, &mut self.help, key)
+    }
+
+    pub(crate) fn review_editor(&mut self, key: KeyEvent) -> Dispatch<ReviewEditorAction> {
+        self.prepare_mode(KeybindingMode::ReviewEditor);
+        dispatch_mode(&mut self.active_sequence_mode, &mut self.review_editor, key)
+    }
+
+    pub(crate) fn command_palette(&mut self, key: KeyEvent) -> Dispatch<PickerAction> {
+        self.prepare_mode(KeybindingMode::CommandPalette);
+        dispatch_mode(
+            &mut self.active_sequence_mode,
+            &mut self.command_palette,
+            key,
+        )
+    }
+
+    pub(crate) fn file_search(&mut self, key: KeyEvent) -> Dispatch<PickerAction> {
+        self.prepare_mode(KeybindingMode::FileSearch);
+        dispatch_mode(&mut self.active_sequence_mode, &mut self.file_search, key)
+    }
+
+    pub(crate) fn file_filter(&mut self, key: KeyEvent) -> Dispatch<FileFilterAction> {
+        self.prepare_mode(KeybindingMode::FileFilter);
+        dispatch_mode(&mut self.active_sequence_mode, &mut self.file_filter, key)
+    }
+
+    pub(crate) fn goto(&mut self, key: KeyEvent) -> Dispatch<LineInputAction> {
+        self.prepare_mode(KeybindingMode::Goto);
+        dispatch_mode(&mut self.active_sequence_mode, &mut self.goto, key)
+    }
+
+    pub(crate) fn search(&mut self, key: KeyEvent) -> Dispatch<LineInputAction> {
+        self.prepare_mode(KeybindingMode::Search);
+        dispatch_mode(&mut self.active_sequence_mode, &mut self.search, key)
+    }
+
+    pub(crate) fn dashboard(&mut self, key: KeyEvent) -> Dispatch<DashboardAction> {
+        self.prepare_mode(KeybindingMode::Dashboard);
+        dispatch_mode(&mut self.active_sequence_mode, &mut self.dashboard, key)
+    }
+
+    pub(crate) fn dashboard_filter(&mut self, key: KeyEvent) -> Dispatch<DashboardFilterAction> {
+        self.prepare_mode(KeybindingMode::DashboardFilter);
+        dispatch_mode(
+            &mut self.active_sequence_mode,
+            &mut self.dashboard_filter,
+            key,
+        )
+    }
+
+    pub(crate) fn normal_keys(&self, action: NormalAction) -> String {
+        self.normal.keys_label(action)
+    }
+
+    pub(crate) fn help_keys(&self, action: HelpAction) -> String {
+        self.help.keys_label(action)
+    }
+
+    pub(crate) fn review_editor_keys(&self, action: ReviewEditorAction) -> String {
+        self.review_editor.keys_label(action)
+    }
+
+    pub(crate) fn dashboard_keys(&self, action: DashboardAction) -> String {
+        self.dashboard.keys_label(action)
+    }
+
+    fn prepare_mode(&mut self, mode: KeybindingMode) {
+        if self
+            .active_sequence_mode
+            .is_some_and(|active| active != mode)
+        {
+            self.clear_sequence();
+        }
+    }
+}
+
+fn dispatch_mode<A: BindingAction + 'static>(
+    active_sequence_mode: &mut Option<KeybindingMode>,
+    mode: &mut ModeBindings<A>,
+    key: KeyEvent,
+) -> Dispatch<A> {
+    let result = mode.dispatch(key);
+    match result {
+        Dispatch::Pending => *active_sequence_mode = Some(mode.mode),
+        _ => *active_sequence_mode = None,
+    }
+    result
+}
+
+impl<A: BindingAction + 'static> ModeBindings<A> {
+    fn build(mode: KeybindingMode, config: &KeybindingsConfig, warnings: &mut Vec<String>) -> Self {
+        let mut effective = default_bindings::<A>();
+        if let Some(overrides) = config.modes.get(mode.id()) {
+            for id in overrides.keys() {
+                if !A::all().iter().any(|action| action.id() == id) {
+                    warnings.push(format!(
+                        "Ignoring unknown keybinding action '{}.{}'",
+                        mode.id(),
+                        id
+                    ));
+                }
+            }
+            for action in A::all() {
+                if let Some(keys) = overrides.get(action.id()) {
+                    effective.insert(action.id(), keys.clone());
+                }
+            }
+        }
+
+        if let Err(error) = validate_effective_bindings::<A>(&effective) {
+            warnings.push(format!(
+                "Ignoring [keybindings.{}]: {}; using defaults for this mode",
+                mode.id(),
+                error
+            ));
+            effective = default_bindings::<A>();
+        }
+
+        let items = A::all()
+            .iter()
+            .map(|action| {
+                (
+                    *action,
+                    Item::new(
+                        effective.get(action.id()).cloned().unwrap_or_default(),
+                        action.description().to_string(),
+                    ),
+                )
+            })
+            .collect();
+        let config = Config::new(items);
+        let prefix_matcher = prefix_matcher(&effective);
+        Self {
+            mode,
+            config,
+            effective,
+            prefix_matcher,
+            buffer: Vec::new(),
+        }
+    }
+
+    fn dispatch(&mut self, key: KeyEvent) -> Dispatch<A> {
+        let mut retry = Some(canonical_key(key));
+        while let Some(next_key) = retry.take() {
+            self.buffer.push(next_key);
+            if let Some(action) = self.config.get_seq(&self.buffer).copied() {
+                self.buffer.clear();
+                return Dispatch::Matched(action);
+            }
+            let keymaps = match keymaps_for_events(&self.buffer) {
+                Some(keymaps) => keymaps,
+                None => {
+                    self.buffer.clear();
+                    return Dispatch::Unmatched;
+                }
+            };
+            if self.prefix_matcher.get(&keymaps).is_some() {
+                return Dispatch::Pending;
+            }
+            let failed_len = self.buffer.len();
+            self.buffer.clear();
+            if failed_len > 1 {
+                retry = Some(next_key);
+            }
+        }
+        Dispatch::Unmatched
+    }
+
+    fn clear_sequence(&mut self) {
+        self.buffer.clear();
+    }
+
+    fn keys_label(&self, action: A) -> String {
+        self.effective
+            .get(action.id())
+            .map(|keys| keys.join(" / "))
+            .unwrap_or_default()
+    }
+}
+
+fn warn_unknown_modes(config: &KeybindingsConfig, warnings: &mut Vec<String>) {
+    for mode in config.modes.keys() {
+        if ![
+            KeybindingMode::Normal.id(),
+            KeybindingMode::Help.id(),
+            KeybindingMode::ReviewEditor.id(),
+            KeybindingMode::CommandPalette.id(),
+            KeybindingMode::FileSearch.id(),
+            KeybindingMode::FileFilter.id(),
+            KeybindingMode::Goto.id(),
+            KeybindingMode::Search.id(),
+            KeybindingMode::Dashboard.id(),
+            KeybindingMode::DashboardFilter.id(),
+        ]
+        .contains(&mode.as_str())
+        {
+            warnings.push(format!(
+                "Ignoring unknown keybinding mode [keybindings.{}]",
+                mode
+            ));
+        }
+    }
+}
+
+fn default_bindings<A: BindingAction + 'static>() -> BTreeMap<&'static str, Vec<String>> {
+    A::all()
+        .iter()
+        .map(|action| {
+            (
+                action.id(),
+                action
+                    .defaults()
+                    .iter()
+                    .map(|key| (*key).to_string())
+                    .collect(),
+            )
+        })
+        .collect()
+}
+
+fn validate_effective_bindings<A: BindingAction + 'static>(
+    bindings: &BTreeMap<&'static str, Vec<String>>,
+) -> Result<(), String> {
+    let mut seen: Vec<(Vec<KeyMap>, &'static str, String)> = Vec::new();
+    let mut ids = HashSet::new();
+    for action in A::all() {
+        ids.insert(action.id());
+    }
+
+    for (id, keys) in bindings {
+        if !ids.contains(id) {
+            continue;
+        }
+        for key in keys {
+            let parsed = parse_seq(key)
+                .map_err(|error| format!("invalid key '{}' for '{}': {}", key, id, error))?;
+            if let Some((_, other_id, other_key)) = seen.iter().find(|(existing, _, _)| {
+                existing == &parsed
+                    || existing.starts_with(&parsed)
+                    || parsed.starts_with(existing.as_slice())
+            }) {
+                return Err(format!(
+                    "key '{}' for '{}' conflicts with '{}' for '{}'",
+                    key, id, other_key, other_id
+                ));
+            }
+            seen.push((parsed, id, key.clone()));
+        }
+    }
+    Ok(())
+}
+
+fn prefix_matcher(bindings: &BTreeMap<&'static str, Vec<String>>) -> Matcher<()> {
+    let mut matcher = Matcher::new();
+    for keys in bindings.values() {
+        for key in keys {
+            if let Ok(sequence) = parse_seq(key) {
+                for len in 1..sequence.len() {
+                    matcher.add(sequence[..len].to_vec(), ());
+                }
+            }
+        }
+    }
+    matcher
+}
+
+fn keymaps_for_events(events: &[KeyEvent]) -> Option<Vec<KeyMap>> {
+    events
+        .iter()
+        .map(|event| event.to_keymap().ok())
+        .collect::<Option<Vec<_>>>()
+}
+
+fn canonical_key(mut key: KeyEvent) -> KeyEvent {
+    let KeyCode::Char(c) = key.code else {
+        return key;
+    };
+    if !key.modifiers.contains(KeyModifiers::SHIFT) || !c.is_ascii_uppercase() {
+        return key;
+    }
+    if key
+        .modifiers
+        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+    {
+        key.code = KeyCode::Char(c.to_ascii_lowercase());
+    } else {
+        key.modifiers.remove(KeyModifiers::SHIFT);
+    }
+    key
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(ch: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(ch), KeyModifiers::empty())
+    }
+
+    fn ctrl(ch: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(ch), KeyModifiers::CONTROL)
+    }
+
+    #[test]
+    fn keybinding_override_replaces_one_action_and_keeps_other_defaults() {
+        let config: crate::config::Config = toml::from_str(
+            r#"
+            [keybindings.normal]
+            step_down = ["v"]
+            "#,
+        )
+        .unwrap();
+        let mut warnings = Vec::new();
+        let mut bindings =
+            Keybindings::from_config_with_warnings(&config.keybindings, &mut warnings);
+
+        assert!(warnings.is_empty(), "{warnings:?}");
+        assert_eq!(
+            bindings.normal(key('v')),
+            Dispatch::Matched(NormalAction::StepDown)
+        );
+        assert_eq!(
+            bindings.normal(key('j')),
+            Dispatch::Unmatched,
+            "overriding an action should replace, not add to, its default keys"
+        );
+        assert_eq!(
+            bindings.normal(key('q')),
+            Dispatch::Matched(NormalAction::Quit),
+            "omitted actions should keep their default bindings"
+        );
+    }
+
+    #[test]
+    fn sequence_prefix_waits_and_failed_sequence_retries_latest_key() {
+        let mut bindings = Keybindings::default();
+
+        assert_eq!(bindings.normal(key('g')), Dispatch::Pending);
+        assert_eq!(
+            bindings.normal(key('j')),
+            Dispatch::Matched(NormalAction::StepDown)
+        );
+    }
+
+    #[test]
+    fn duplicate_effective_key_falls_back_mode_to_defaults() {
+        let config = KeybindingsConfig {
+            modes: BTreeMap::from([(
+                "normal".to_string(),
+                BTreeMap::from([("toggle_help".to_string(), vec!["q".to_string()])]),
+            )]),
+        };
+        let mut warnings = Vec::new();
+        let mut bindings = Keybindings::from_config_with_warnings(&config, &mut warnings);
+
+        assert!(warnings
+            .iter()
+            .any(|warning| warning.contains("using defaults for this mode")));
+        assert_eq!(
+            bindings.normal(key('?')),
+            Dispatch::Matched(NormalAction::ToggleHelp)
+        );
+        assert_eq!(
+            bindings.normal(key('q')),
+            Dispatch::Matched(NormalAction::Quit)
+        );
+    }
+
+    #[test]
+    fn prefix_conflict_falls_back_mode_to_defaults() {
+        let config = KeybindingsConfig {
+            modes: BTreeMap::from([(
+                "normal".to_string(),
+                BTreeMap::from([("goto_start".to_string(), vec!["g".to_string()])]),
+            )]),
+        };
+        let mut warnings = Vec::new();
+        let mut bindings = Keybindings::from_config_with_warnings(&config, &mut warnings);
+
+        assert!(warnings
+            .iter()
+            .any(|warning| warning.contains("using defaults for this mode")));
+        assert_eq!(
+            bindings.normal(key('g')),
+            Dispatch::Pending,
+            "prefix conflicts should be rejected so longer default sequences remain reachable"
+        );
+    }
+
+    #[test]
+    fn switching_modes_clears_pending_sequence() {
+        let mut bindings = Keybindings::default();
+
+        assert_eq!(bindings.normal(key('g')), Dispatch::Pending);
+        assert_eq!(
+            bindings.help(key('q')),
+            Dispatch::Matched(HelpAction::Close)
+        );
+        assert_eq!(
+            bindings.normal(key('g')),
+            Dispatch::Pending,
+            "returning to normal mode should not reuse the stale first g"
+        );
+    }
+
+    #[test]
+    fn ctrl_shift_binding_matches_configured_default() {
+        let mut bindings = Keybindings::default();
+        let key = KeyEvent::new(
+            KeyCode::Char('p'),
+            KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+        );
+
+        assert_eq!(
+            bindings.normal(key),
+            Dispatch::Matched(NormalAction::OpenFileSearch)
+        );
+        assert_eq!(
+            bindings.normal(ctrl('p')),
+            Dispatch::Matched(NormalAction::OpenCommandPalette)
+        );
+        let key = KeyEvent::new(
+            KeyCode::Char('P'),
+            KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+        );
+        assert_eq!(
+            bindings.normal(key),
+            Dispatch::Matched(NormalAction::OpenFileSearch)
+        );
+    }
+
+    #[test]
+    fn shifted_uppercase_events_match_uppercase_defaults() {
+        let mut bindings = Keybindings::default();
+        let key = KeyEvent::new(KeyCode::Char('P'), KeyModifiers::SHIFT);
+
+        assert_eq!(
+            bindings.normal(key),
+            Dispatch::Matched(NormalAction::TogglePeekHunk)
+        );
+    }
+}

--- a/crates/oyo/src/main.rs
+++ b/crates/oyo/src/main.rs
@@ -5,6 +5,7 @@ mod blame;
 mod color;
 mod config;
 mod dashboard;
+mod keybindings;
 mod syntax;
 #[cfg(test)]
 mod test_utils;

--- a/crates/oyo/src/main.rs
+++ b/crates/oyo/src/main.rs
@@ -5,6 +5,7 @@ mod blame;
 mod color;
 mod config;
 mod dashboard;
+mod input;
 mod keybindings;
 mod syntax;
 #[cfg(test)]
@@ -14,6 +15,8 @@ mod ui;
 mod views;
 
 use crate::dashboard::{Dashboard, DashboardConfig, DashboardSelection};
+use crate::input::handle_app_key;
+use crate::keybindings::{DashboardAction, DashboardFilterAction, Dispatch, Keybindings};
 use crate::syntax::{list_syntax_themes, SyntaxEngine};
 use crate::time_format::TimeFormatter;
 use anyhow::{anyhow, Context, Result};
@@ -723,6 +726,13 @@ fn open_current_file_in_editor(
 }
 
 fn apply_config_to_app(app: &mut App, config: &config::Config, args: &Args, light_mode: bool) {
+    let mut keybinding_warnings = Vec::new();
+    app.keybindings =
+        Keybindings::from_config_with_warnings(&config.keybindings, &mut keybinding_warnings);
+    for warning in keybinding_warnings {
+        eprintln!("Warning: {warning}");
+    }
+
     app.zen_mode = config.ui.zen;
     app.animation_enabled = config.playback.animation;
     app.animation_duration = config.playback.animation_duration;
@@ -1475,734 +1485,7 @@ fn run_app(
                 Event::Key(key)
                     if matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) =>
                 {
-                    if app.show_help {
-                        match key.code {
-                            KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => {
-                                app.toggle_help();
-                            }
-                            KeyCode::Down | KeyCode::Char('j') => {
-                                app.help_scroll_down();
-                            }
-                            KeyCode::Up | KeyCode::Char('k') => {
-                                app.help_scroll_up();
-                            }
-                            _ => {}
-                        }
-                        continue;
-                    }
-
-                    if app.review_editor_active() {
-                        match key.code {
-                            KeyCode::Esc if !app.review_cancel_mention_picker() => {
-                                app.review_cancel_editor();
-                            }
-                            KeyCode::Enter if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                                app.review_save_editor();
-                            }
-                            KeyCode::Enter if !app.review_accept_mention() => {
-                                app.review_insert_newline();
-                            }
-                            KeyCode::Tab => {
-                                let _ = app.review_accept_mention();
-                            }
-                            KeyCode::Backspace => app.review_backspace(),
-                            KeyCode::Delete => app.review_delete(),
-                            KeyCode::Left => app.review_move_left(),
-                            KeyCode::Right => app.review_move_right(),
-                            KeyCode::Up => {
-                                if app.review_mention_picker_active() {
-                                    app.review_mention_move_selection(-1);
-                                } else {
-                                    app.review_move_up();
-                                }
-                            }
-                            KeyCode::Down => {
-                                if app.review_mention_picker_active() {
-                                    app.review_mention_move_selection(1);
-                                } else {
-                                    app.review_move_down();
-                                }
-                            }
-                            KeyCode::Home => app.review_move_home(),
-                            KeyCode::End => app.review_move_end(),
-                            KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                                app.review_clear_editor_text();
-                            }
-                            KeyCode::Char('n')
-                                if key.modifiers.contains(KeyModifiers::CONTROL)
-                                    && app.review_mention_picker_active() =>
-                            {
-                                app.review_mention_move_selection(1);
-                            }
-                            KeyCode::Char('p')
-                                if key.modifiers.contains(KeyModifiers::CONTROL)
-                                    && app.review_mention_picker_active() =>
-                            {
-                                app.review_mention_move_selection(-1);
-                            }
-                            KeyCode::Char(c)
-                                if !key.modifiers.contains(KeyModifiers::CONTROL)
-                                    && !key.modifiers.contains(KeyModifiers::ALT) =>
-                            {
-                                app.review_insert_char(c);
-                            }
-                            _ => {}
-                        }
-                        continue;
-                    }
-
-                    let is_ctrl_p = key.modifiers.contains(KeyModifiers::CONTROL)
-                        && matches!(key.code, KeyCode::Char('p') | KeyCode::Char('P'));
-                    let is_ctrl_shift_p = key.modifiers.contains(KeyModifiers::CONTROL)
-                        && key.modifiers.contains(KeyModifiers::SHIFT)
-                        && matches!(key.code, KeyCode::Char('p') | KeyCode::Char('P'));
-
-                    if is_ctrl_shift_p {
-                        if app.file_search_active() {
-                            app.stop_file_search();
-                        } else {
-                            app.start_file_search();
-                        }
-                        continue;
-                    }
-
-                    if is_ctrl_p {
-                        if app.command_palette_active() {
-                            app.stop_command_palette();
-                        } else {
-                            app.start_command_palette();
-                        }
-                        continue;
-                    }
-
-                    if app.command_palette_active() {
-                        match key.code {
-                            KeyCode::Esc => {
-                                app.stop_command_palette();
-                            }
-                            KeyCode::Enter => {
-                                app.apply_command_palette_selection();
-                            }
-                            KeyCode::Backspace => {
-                                if app.command_palette_query().is_empty() {
-                                    app.stop_command_palette();
-                                } else {
-                                    app.pop_command_palette_char();
-                                }
-                            }
-                            KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                                app.clear_command_palette_text();
-                            }
-                            KeyCode::Down => {
-                                app.move_command_palette_selection(1);
-                            }
-                            KeyCode::Up => {
-                                app.move_command_palette_selection(-1);
-                            }
-                            KeyCode::Char(c)
-                                if !key.modifiers.contains(KeyModifiers::CONTROL)
-                                    && !key.modifiers.contains(KeyModifiers::ALT) =>
-                            {
-                                app.push_command_palette_char(c);
-                            }
-                            _ => {}
-                        }
-                        continue;
-                    }
-
-                    if app.file_search_active() {
-                        match key.code {
-                            KeyCode::Esc => {
-                                app.stop_file_search();
-                            }
-                            KeyCode::Enter => {
-                                app.apply_file_search_selection();
-                            }
-                            KeyCode::Backspace => {
-                                if app.file_search_query().is_empty() {
-                                    app.stop_file_search();
-                                } else {
-                                    app.pop_file_search_char();
-                                }
-                            }
-                            KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                                app.clear_file_search_text();
-                            }
-                            KeyCode::Down => {
-                                app.move_file_search_selection(1);
-                            }
-                            KeyCode::Up => {
-                                app.move_file_search_selection(-1);
-                            }
-                            KeyCode::Char(c)
-                                if !key.modifiers.contains(KeyModifiers::CONTROL)
-                                    && !key.modifiers.contains(KeyModifiers::ALT) =>
-                            {
-                                app.push_file_search_char(c);
-                            }
-                            _ => {}
-                        }
-                        continue;
-                    }
-
-                    if app.file_filter_active {
-                        match key.code {
-                            KeyCode::Esc | KeyCode::Enter => {
-                                app.stop_file_filter();
-                            }
-                            KeyCode::Backspace => {
-                                app.pop_file_filter_char();
-                            }
-                            KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                                app.clear_file_filter();
-                            }
-                            KeyCode::Char(c)
-                                if !key.modifiers.contains(KeyModifiers::CONTROL)
-                                    && !key.modifiers.contains(KeyModifiers::ALT) =>
-                            {
-                                app.push_file_filter_char(c);
-                            }
-                            _ => {}
-                        }
-                        continue;
-                    }
-                    if app.goto_active() {
-                        match key.code {
-                            KeyCode::Esc => {
-                                app.clear_goto();
-                            }
-                            KeyCode::Enter => {
-                                app.apply_goto();
-                                app.clear_goto();
-                            }
-                            KeyCode::Backspace => {
-                                if app.goto_query().is_empty() {
-                                    app.clear_goto();
-                                } else {
-                                    app.pop_goto_char();
-                                }
-                            }
-                            KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                                app.clear_goto_text();
-                            }
-                            KeyCode::Char(c)
-                                if !key.modifiers.contains(KeyModifiers::CONTROL)
-                                    && !key.modifiers.contains(KeyModifiers::ALT) =>
-                            {
-                                app.push_goto_char(c);
-                            }
-                            _ => {}
-                        }
-                        continue;
-                    }
-                    if app.search_active() {
-                        match key.code {
-                            KeyCode::Esc => {
-                                app.clear_search();
-                            }
-                            KeyCode::Enter => {
-                                app.stop_search();
-                                app.search_next();
-                            }
-                            KeyCode::Backspace => {
-                                if app.search_query().is_empty() {
-                                    app.clear_search();
-                                } else {
-                                    app.pop_search_char();
-                                }
-                            }
-                            KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                                app.clear_search_text();
-                            }
-                            KeyCode::Char(c)
-                                if !key.modifiers.contains(KeyModifiers::CONTROL)
-                                    && !key.modifiers.contains(KeyModifiers::ALT) =>
-                            {
-                                app.push_search_char(c);
-                            }
-                            _ => {}
-                        }
-                        continue;
-                    }
-
-                    if app.pending_g_prefix {
-                        let is_plain_g = matches!(key.code, KeyCode::Char('g'))
-                            && !key.modifiers.contains(KeyModifiers::CONTROL)
-                            && !key.modifiers.contains(KeyModifiers::ALT);
-                        let is_blame_gb = matches!(key.code, KeyCode::Char('b'))
-                            && !key.modifiers.contains(KeyModifiers::CONTROL)
-                            && !key.modifiers.contains(KeyModifiers::ALT);
-                        let is_patch_line = matches!(key.code, KeyCode::Char('y'))
-                            && !key.modifiers.contains(KeyModifiers::CONTROL)
-                            && !key.modifiers.contains(KeyModifiers::ALT);
-                        let is_patch_hunk = matches!(key.code, KeyCode::Char('Y'))
-                            && !key.modifiers.contains(KeyModifiers::CONTROL)
-                            && !key.modifiers.contains(KeyModifiers::ALT);
-                        if is_plain_g {
-                            app.pending_g_prefix = false;
-                            app.reset_count();
-                            app.goto_start();
-                            continue;
-                        }
-                        if is_blame_gb {
-                            app.pending_g_prefix = false;
-                            app.reset_count();
-                            if app.blame_enabled {
-                                app.trigger_blame_hint();
-                            }
-                            continue;
-                        }
-                        if is_patch_line {
-                            app.pending_g_prefix = false;
-                            app.reset_count();
-                            app.yank_current_change_patch();
-                            continue;
-                        }
-                        if is_patch_hunk {
-                            app.pending_g_prefix = false;
-                            app.reset_count();
-                            app.yank_current_hunk_patch();
-                            continue;
-                        }
-                        app.pending_g_prefix = false;
-                    }
-                    if matches!(key.code, KeyCode::Esc)
-                        && !app.show_help
-                        && !app.show_path_popup
-                        && (app.search_active()
-                            || !app.search_query().is_empty()
-                            || app.goto_active()
-                            || !app.goto_query().is_empty())
-                    {
-                        app.reset_count();
-                        app.clear_search();
-                        app.clear_goto();
-                        continue;
-                    }
-
-                    match key.code {
-                        // Digit keys for vim-style counts (e.g., 10j, 5l)
-                        KeyCode::Char(c @ '0'..='9') => {
-                            // Don't treat '0' as count if no pending count (it's a command)
-                            if c == '0' && app.pending_count.is_none() {
-                                // '0' without pending count = go to start of line (like vim)
-                                app.scroll_to_line_start();
-                            } else {
-                                app.push_count_digit(c as u8 - b'0');
-                            }
-                        }
-                        // $ = go to end of line (horizontal scroll to end, like vim)
-                        KeyCode::Char('$') => {
-                            app.reset_count();
-                            app.scroll_to_line_end();
-                        }
-                        KeyCode::Char('q') | KeyCode::Esc => {
-                            app.reset_count();
-                            if app.show_help {
-                                app.show_help = false;
-                            } else if app.show_path_popup {
-                                app.show_path_popup = false;
-                            } else {
-                                app.submit_review_and_quit();
-                                continue;
-                            }
-                        }
-                        // Step navigation (supports count)
-                        KeyCode::Down | KeyCode::Char('j') => {
-                            let count = if app.pending_count.is_some() {
-                                app.take_count()
-                            } else {
-                                coalesce_key_repeats(key, &mut pending_event)?
-                            };
-                            for _ in 0..count {
-                                if app.file_list_focused {
-                                    app.next_file();
-                                } else if app.stepping {
-                                    app.next_step();
-                                } else {
-                                    app.scroll_down();
-                                }
-                            }
-                        }
-                        KeyCode::Up | KeyCode::Char('k') => {
-                            let count = if app.pending_count.is_some() {
-                                app.take_count()
-                            } else {
-                                coalesce_key_repeats(key, &mut pending_event)?
-                            };
-                            for _ in 0..count {
-                                if app.file_list_focused {
-                                    app.prev_file();
-                                } else if app.stepping {
-                                    app.prev_step();
-                                } else {
-                                    app.scroll_up();
-                                }
-                            }
-                        }
-                        // Hunk navigation (h/l and arrow keys, supports count)
-                        KeyCode::Right | KeyCode::Char('l') => {
-                            let count = if app.pending_count.is_some() {
-                                app.take_count()
-                            } else {
-                                coalesce_key_repeats(key, &mut pending_event)?
-                            };
-                            app.defer_view_build_for_jump();
-                            for _ in 0..count {
-                                if app.stepping {
-                                    app.next_hunk();
-                                } else {
-                                    // Scroll-only navigation in no-step mode
-                                    app.next_hunk_scroll();
-                                }
-                            }
-                        }
-                        KeyCode::Left | KeyCode::Char('h') => {
-                            let count = if app.pending_count.is_some() {
-                                app.take_count()
-                            } else {
-                                coalesce_key_repeats(key, &mut pending_event)?
-                            };
-                            app.defer_view_build_for_jump();
-                            for _ in 0..count {
-                                if app.stepping {
-                                    app.prev_hunk();
-                                } else {
-                                    // Scroll-only navigation in no-step mode
-                                    app.prev_hunk_scroll();
-                                }
-                            }
-                        }
-                        // Jump to begin/end of current hunk
-                        KeyCode::Char('b') => {
-                            app.reset_count();
-                            app.defer_view_build_for_jump();
-                            if app.stepping {
-                                app.goto_hunk_start();
-                            } else {
-                                app.goto_hunk_start_scroll();
-                            }
-                        }
-                        KeyCode::Char('e') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                            app.reset_count();
-                            open_current_file_in_editor(terminal, app, editor_config)?;
-                        }
-                        KeyCode::Char('e') => {
-                            app.reset_count();
-                            app.defer_view_build_for_jump();
-                            if app.stepping {
-                                app.goto_hunk_end();
-                            } else {
-                                app.goto_hunk_end_scroll();
-                            }
-                        }
-                        // Peek old without stepping (unified view)
-                        KeyCode::Char('p') => {
-                            app.reset_count();
-                            if app.stepping {
-                                app.toggle_peek_old_change();
-                            }
-                        }
-                        KeyCode::Char('P') => {
-                            app.reset_count();
-                            if app.stepping {
-                                app.toggle_peek_old_hunk();
-                            }
-                        }
-                        // Yank to clipboard
-                        KeyCode::Char('y') => {
-                            app.reset_count();
-                            app.yank_current_change();
-                        }
-                        KeyCode::Char('Y') => {
-                            app.reset_count();
-                            app.yank_current_hunk();
-                        }
-                        KeyCode::Char('g') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                            app.reset_count();
-                            // Toggle file path popup
-                            app.toggle_path_popup();
-                        }
-                        KeyCode::Char('o')
-                            if !key.modifiers.contains(KeyModifiers::CONTROL)
-                                && !key.modifiers.contains(KeyModifiers::ALT) =>
-                        {
-                            app.reset_count();
-                            open_current_file_in_editor(terminal, app, editor_config)?;
-                        }
-                        KeyCode::Home => {
-                            app.reset_count();
-                            app.defer_view_build_for_jump();
-                            app.goto_start();
-                        }
-                        KeyCode::Char('g') => {
-                            app.reset_count();
-                            app.pending_g_prefix = true;
-                        }
-                        KeyCode::End | KeyCode::Char('G') => {
-                            app.reset_count();
-                            app.defer_view_build_for_jump();
-                            app.goto_end();
-                        }
-                        KeyCode::Char('<') => {
-                            app.reset_count();
-                            app.defer_view_build_for_jump();
-                            if app.stepping {
-                                app.goto_first_step();
-                            } else {
-                                app.goto_first_hunk_scroll();
-                            }
-                        }
-                        KeyCode::Char('>') => {
-                            app.reset_count();
-                            app.defer_view_build_for_jump();
-                            if app.stepping {
-                                app.goto_last_step();
-                            } else {
-                                app.goto_last_hunk_scroll();
-                            }
-                        }
-                        // File navigation (supports count)
-                        KeyCode::Char('[') => {
-                            let count = app.take_count();
-                            for _ in 0..count {
-                                app.prev_file();
-                            }
-                        }
-                        KeyCode::Char(']') => {
-                            let count = app.take_count();
-                            for _ in 0..count {
-                                app.next_file();
-                            }
-                        }
-                        // General controls
-                        KeyCode::Char(' ') => {
-                            app.reset_count();
-                            if app.stepping {
-                                app.toggle_autoplay();
-                            }
-                        }
-                        KeyCode::Char('B') => {
-                            app.reset_count();
-                            if app.stepping {
-                                app.toggle_autoplay_reverse();
-                            }
-                        }
-                        KeyCode::Tab => {
-                            app.reset_count();
-                            app.toggle_view_mode();
-                        }
-                        KeyCode::BackTab => {
-                            app.reset_count();
-                            app.toggle_view_mode_reverse();
-                        }
-                        // Scroll navigation (supports count)
-                        KeyCode::Char('K') => {
-                            let count = app.take_count();
-                            for _ in 0..count {
-                                app.scroll_up();
-                            }
-                        }
-                        KeyCode::Char('J') => {
-                            let count = app.take_count();
-                            for _ in 0..count {
-                                app.scroll_down();
-                            }
-                        }
-                        KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                            app.reset_count();
-                            if let Ok((_, rows)) = crossterm::terminal::size() {
-                                let viewport_height = rows.saturating_sub(6) as usize;
-                                app.scroll_half_page_up(viewport_height);
-                            }
-                        }
-                        KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                            app.reset_count();
-                            if let Ok((_, rows)) = crossterm::terminal::size() {
-                                let viewport_height = rows.saturating_sub(6) as usize;
-                                app.scroll_half_page_down(viewport_height);
-                            }
-                        }
-                        KeyCode::Enter => {
-                            app.reset_count();
-                            // Switch focus between file list and diff view
-                            if app.is_multi_file() {
-                                app.file_list_focused = !app.file_list_focused;
-                                if !app.file_list_focused {
-                                    app.stop_file_filter();
-                                }
-                            }
-                        }
-                        KeyCode::Char('+') | KeyCode::Char('=') => {
-                            app.reset_count();
-                            if app.is_multi_file() && app.file_list_focused {
-                                if let Ok((cols, _)) = crossterm::terminal::size() {
-                                    app.resize_file_panel(2, cols);
-                                }
-                            } else {
-                                app.increase_speed();
-                            }
-                        }
-                        KeyCode::Char('-') => {
-                            app.reset_count();
-                            if app.is_multi_file() && app.file_list_focused {
-                                if let Ok((cols, _)) = crossterm::terminal::size() {
-                                    app.resize_file_panel(-2, cols);
-                                }
-                            } else {
-                                app.decrease_speed();
-                            }
-                        }
-                        KeyCode::Char('a') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                            app.reset_count();
-                            // Toggle file list focus (Ctrl+A)
-                            if app.is_multi_file() {
-                                app.file_list_focused = !app.file_list_focused;
-                                if !app.file_list_focused {
-                                    app.stop_file_filter();
-                                }
-                            }
-                        }
-                        KeyCode::Char('a') => {
-                            app.reset_count();
-                            // Toggle animation mode
-                            app.toggle_animation();
-                        }
-                        KeyCode::Char('w') => {
-                            app.reset_count();
-                            // Toggle line wrap
-                            app.toggle_line_wrap();
-                        }
-                        KeyCode::Char('t') => {
-                            app.reset_count();
-                            // Toggle syntax highlighting mode
-                            app.toggle_syntax();
-                        }
-                        KeyCode::Char('E') => {
-                            app.reset_count();
-                            if app.view_mode == ViewMode::Evolution {
-                                app.toggle_evo_syntax();
-                            }
-                        }
-                        KeyCode::Char('s') => {
-                            app.reset_count();
-                            // Toggle stepping state
-                            app.toggle_stepping();
-                        }
-                        KeyCode::Char('S') => {
-                            app.reset_count();
-                            // Toggle strikethrough for deletions
-                            app.toggle_strikethrough_deletions();
-                        }
-                        KeyCode::Char('H') => {
-                            // Scroll left (horizontal)
-                            let count = app.take_count();
-                            for _ in 0..count {
-                                app.scroll_left();
-                            }
-                        }
-                        KeyCode::Char('L') => {
-                            // Scroll right (horizontal)
-                            let count = app.take_count();
-                            for _ in 0..count {
-                                app.scroll_right();
-                            }
-                        }
-                        KeyCode::Char('z') => {
-                            app.reset_count();
-                            // Center on active change (like Vim's zz)
-                            if let Ok((_, rows)) = crossterm::terminal::size() {
-                                let viewport_height = rows.saturating_sub(4) as usize;
-                                app.center_on_active(viewport_height);
-                            }
-                        }
-                        KeyCode::Char('Z') => {
-                            app.reset_count();
-                            // Toggle zen mode
-                            app.toggle_zen();
-                        }
-                        KeyCode::Char('r') => {
-                            app.replay_step();
-                        }
-                        KeyCode::Char('R') => {
-                            app.reset_count();
-                            // Refresh the full file set so added/removed files are reflected.
-                            if app.multi_diff.is_git_mode() {
-                                app.refresh_all_files();
-                            } else {
-                                app.refresh_current_file();
-                            }
-                        }
-                        KeyCode::Char('f') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                            app.reset_count();
-                            // Toggle file panel visibility
-                            if app.is_multi_file() {
-                                app.toggle_file_panel();
-                            }
-                        }
-                        KeyCode::Char('f') => {
-                            app.reset_count();
-                            app.toggle_fold_context();
-                        }
-                        KeyCode::Char('/') => {
-                            app.reset_count();
-                            if app.file_list_focused {
-                                app.start_file_filter();
-                            } else {
-                                app.start_search();
-                            }
-                        }
-                        KeyCode::Char(':') => {
-                            app.reset_count();
-                            if !app.file_list_focused {
-                                app.start_goto();
-                            }
-                        }
-                        KeyCode::Char('n') => {
-                            app.reset_count();
-                            app.search_next();
-                        }
-                        KeyCode::Char('N') => {
-                            app.reset_count();
-                            app.search_prev();
-                        }
-                        KeyCode::Char('c') => {
-                            app.reset_count();
-                            app.next_conflict();
-                        }
-                        KeyCode::Char('C') => {
-                            app.reset_count();
-                            app.prev_conflict();
-                        }
-                        KeyCode::Char('m') => {
-                            app.reset_count();
-                            app.start_line_comment();
-                        }
-                        KeyCode::Char('M') => {
-                            app.reset_count();
-                            app.start_hunk_comment();
-                        }
-                        KeyCode::Char('x') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                            app.reset_count();
-                            app.clear_all_review_comments();
-                        }
-                        KeyCode::Char('x') => {
-                            app.reset_count();
-                            app.remove_line_comment_at_cursor();
-                        }
-                        KeyCode::Char('X') => {
-                            app.reset_count();
-                            app.remove_hunk_comment_at_cursor();
-                        }
-                        KeyCode::Char('?') => {
-                            app.reset_count();
-                            // Toggle help popover
-                            app.toggle_help();
-                        }
-                        _ => {
-                            app.reset_count();
-                        }
-                    }
+                    handle_app_key(app, key, &mut pending_event, terminal, editor_config)?;
                 }
                 _ => {}
             }
@@ -2262,81 +1545,83 @@ fn run_dashboard<B: Backend>(
                     let list_height =
                         dashboard.list_height(terminal.size().map_err(|e| anyhow!("{e}"))?.height);
                     if dashboard.filter_active() {
-                        match key.code {
-                            KeyCode::Esc => {
+                        match dashboard.keybindings_mut().dashboard_filter(key) {
+                            Dispatch::Matched(DashboardFilterAction::Cancel) => {
                                 dashboard.stop_filter();
                             }
-                            KeyCode::Enter => {
+                            Dispatch::Matched(DashboardFilterAction::Accept) => {
                                 if let Some(selection) = dashboard.selection() {
                                     return Ok(Some(selection));
                                 }
                             }
-                            KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                            Dispatch::Matched(DashboardFilterAction::Clear) => {
                                 dashboard.clear_filter();
                             }
-                            KeyCode::Backspace => {
+                            Dispatch::Matched(DashboardFilterAction::Backspace) => {
                                 dashboard.pop_filter_char();
                             }
-                            KeyCode::Char('j') | KeyCode::Down => {
+                            Dispatch::Matched(DashboardFilterAction::SelectNext) => {
                                 dashboard.move_selection(1, list_height);
                             }
-                            KeyCode::Char('k') | KeyCode::Up => {
+                            Dispatch::Matched(DashboardFilterAction::SelectPrev) => {
                                 dashboard.move_selection(-1, list_height);
                             }
-                            KeyCode::PageDown => {
+                            Dispatch::Matched(DashboardFilterAction::PageDown) => {
                                 dashboard.page_down(list_height);
                             }
-                            KeyCode::PageUp => {
+                            Dispatch::Matched(DashboardFilterAction::PageUp) => {
                                 dashboard.page_up(list_height);
                             }
-                            KeyCode::Char('g') | KeyCode::Home => {
+                            Dispatch::Matched(DashboardFilterAction::SelectFirst) => {
                                 dashboard.select_first(list_height);
                             }
-                            KeyCode::Char('G') | KeyCode::End => {
+                            Dispatch::Matched(DashboardFilterAction::SelectLast) => {
                                 dashboard.select_last(list_height);
                             }
-                            KeyCode::Char(ch) => {
-                                dashboard.push_filter_char(ch);
+                            Dispatch::Pending => {}
+                            Dispatch::Unmatched => {
+                                if let Some(ch) = printable_dashboard_char(key) {
+                                    dashboard.push_filter_char(ch);
+                                }
                             }
-                            _ => {}
                         }
                         continue;
                     }
-                    match key.code {
-                        KeyCode::Esc | KeyCode::Char('q') => return Ok(None),
-                        KeyCode::Char('/') => {
+                    match dashboard.keybindings_mut().dashboard(key) {
+                        Dispatch::Matched(DashboardAction::Quit) => return Ok(None),
+                        Dispatch::Matched(DashboardAction::StartFilter) => {
                             dashboard.start_filter();
                         }
-                        KeyCode::Char('r') => {
+                        Dispatch::Matched(DashboardAction::ClearPin) => {
                             dashboard.clear_pin();
                         }
-                        KeyCode::Char(' ') => {
+                        Dispatch::Matched(DashboardAction::TogglePin) => {
                             dashboard.toggle_pin();
                         }
-                        KeyCode::Enter => {
+                        Dispatch::Matched(DashboardAction::Accept) => {
                             if let Some(selection) = dashboard.selection() {
                                 return Ok(Some(selection));
                             }
                         }
-                        KeyCode::Char('j') | KeyCode::Down => {
+                        Dispatch::Matched(DashboardAction::SelectNext) => {
                             dashboard.move_selection(1, list_height);
                         }
-                        KeyCode::Char('k') | KeyCode::Up => {
+                        Dispatch::Matched(DashboardAction::SelectPrev) => {
                             dashboard.move_selection(-1, list_height);
                         }
-                        KeyCode::PageDown => {
+                        Dispatch::Matched(DashboardAction::PageDown) => {
                             dashboard.page_down(list_height);
                         }
-                        KeyCode::PageUp => {
+                        Dispatch::Matched(DashboardAction::PageUp) => {
                             dashboard.page_up(list_height);
                         }
-                        KeyCode::Char('g') | KeyCode::Home => {
+                        Dispatch::Matched(DashboardAction::SelectFirst) => {
                             dashboard.select_first(list_height);
                         }
-                        KeyCode::Char('G') | KeyCode::End => {
+                        Dispatch::Matched(DashboardAction::SelectLast) => {
                             dashboard.select_last(list_height);
                         }
-                        _ => {}
+                        Dispatch::Pending | Dispatch::Unmatched => {}
                     }
                 }
                 Event::Mouse(mouse) => {
@@ -2363,6 +1648,18 @@ fn run_dashboard<B: Backend>(
                 _ => {}
             }
         }
+    }
+}
+
+fn printable_dashboard_char(key: KeyEvent) -> Option<char> {
+    match key.code {
+        KeyCode::Char(ch)
+            if !key.modifiers.contains(KeyModifiers::CONTROL)
+                && !key.modifiers.contains(KeyModifiers::ALT) =>
+        {
+            Some(ch)
+        }
+        _ => None,
     }
 }
 
@@ -2399,6 +1696,7 @@ fn run_commit_picker<B: Backend>(
         primary_marker: config.ui.primary_marker.clone(),
         extent_marker: config.ui.extent_marker.clone(),
         time_format,
+        keybindings: Keybindings::from_config(&config.keybindings),
     });
 
     let selection = run_dashboard(terminal, &mut dashboard)?;

--- a/crates/oyo/src/ui.rs
+++ b/crates/oyo/src/ui.rs
@@ -2,6 +2,7 @@
 
 use crate::app::{App, ViewMode, DIFF_VIEW_MIN_WIDTH, FILE_PANEL_MIN_WIDTH};
 use crate::color;
+use crate::keybindings::{HelpAction, NormalAction, ReviewEditorAction};
 use crate::views::{render_blame, render_evolution, render_split, render_unified_pane};
 use oyo_core::{multi::DiffStatus, FileStatus};
 use ratatui::{
@@ -70,6 +71,18 @@ fn truncate_filename_keep_ext(name: &str, max_width: usize) -> String {
 
 fn text_width(text: &str) -> usize {
     UnicodeWidthStr::width(text)
+}
+
+fn paired<A>(keys: &impl Fn(A) -> String, first: A, second: A) -> String {
+    format!("{} / {}", keys(first), keys(second))
+}
+
+fn counted_binding_label(binding: &str) -> String {
+    binding
+        .split(" / ")
+        .map(|key| format!("<count>{key}"))
+        .collect::<Vec<_>>()
+        .join(" / ")
 }
 
 fn spans_width(spans: &[Span]) -> usize {
@@ -1227,7 +1240,11 @@ fn draw_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
         } else if has_query {
             app.file_filter.clone()
         } else {
-            "\"/\" Filter".to_string()
+            format!(
+                "{} Filter",
+                app.keybindings
+                    .normal_keys(NormalAction::OpenSearchOrFileFilter)
+            )
         };
         let filter_style = if app.file_filter_active {
             Style::default().fg(app.theme.text)
@@ -1497,7 +1514,12 @@ fn draw_review_editor_overlay(frame: &mut Frame, app: &mut App) {
                 .add_modifier(Modifier::BOLD),
         ))
         .title_bottom(Span::styled(
-            " Ctrl+Enter save • Esc cancel • @ mention ",
+            format!(
+                " {} save • {} cancel • @ mention ",
+                app.keybindings.review_editor_keys(ReviewEditorAction::Save),
+                app.keybindings
+                    .review_editor_keys(ReviewEditorAction::Cancel)
+            ),
             Style::default().fg(app.theme.text_muted),
         ))
         .borders(Borders::ALL)
@@ -1744,45 +1766,83 @@ fn draw_help_popover(frame: &mut Frame, app: &mut App) {
     let dim_style = Style::default().fg(app.theme.text_muted);
     let section_style = Style::default().fg(app.theme.primary);
 
+    let normal = |action| app.keybindings.normal_keys(action);
+    let help = |action| app.keybindings.help_keys(action);
     let mut help_keys = vec![
-        "j / k / ↑↓",
-        "h / l / ←→",
-        "b / e",
-        "p / P",
-        "y / Y",
-        "/",
-        "n / N",
-        "c / C",
-        "m / M",
-        "x / X",
-        "Ctrl+x",
-        ":<line>",
-        ":h<num>",
-        ":s<num>",
-        "< / >",
-        "gg / G",
-        "J / K",
-        "H / L",
-        "0 / $",
-        "^U / ^D",
-        "^G",
-        "o / Ctrl+e",
-        "z",
-        "w",
-        "t",
-        "s",
-        "S",
-        "Space / B",
-        "+ / -",
-        "a",
-        "Tab",
-        "Z",
-        "r",
-        "Ctrl+P",
-        "Ctrl+Shift+P",
+        paired(&normal, NormalAction::StepDown, NormalAction::StepUp),
+        paired(&normal, NormalAction::PrevHunk, NormalAction::NextHunk),
+        paired(&normal, NormalAction::HunkStart, NormalAction::HunkEnd),
+        paired(
+            &normal,
+            NormalAction::TogglePeekChange,
+            NormalAction::TogglePeekHunk,
+        ),
+        paired(&normal, NormalAction::YankChange, NormalAction::YankHunk),
+        normal(NormalAction::OpenSearchOrFileFilter),
+        paired(&normal, NormalAction::SearchNext, NormalAction::SearchPrev),
+        paired(
+            &normal,
+            NormalAction::NextConflict,
+            NormalAction::PrevConflict,
+        ),
+        paired(
+            &normal,
+            NormalAction::LineComment,
+            NormalAction::HunkComment,
+        ),
+        paired(
+            &normal,
+            NormalAction::RemoveLineComment,
+            NormalAction::RemoveHunkComment,
+        ),
+        normal(NormalAction::ClearComments),
+        ":<line>".to_string(),
+        ":h<num>".to_string(),
+        ":s<num>".to_string(),
+        paired(&normal, NormalAction::FirstStep, NormalAction::LastStep),
+        paired(&normal, NormalAction::GotoStart, NormalAction::GotoEnd),
+        paired(&normal, NormalAction::ScrollDown, NormalAction::ScrollUp),
+        paired(&normal, NormalAction::ScrollLeft, NormalAction::ScrollRight),
+        paired(&normal, NormalAction::LineStart, NormalAction::LineEnd),
+        paired(
+            &normal,
+            NormalAction::HalfPageUp,
+            NormalAction::HalfPageDown,
+        ),
+        normal(NormalAction::TogglePathPopup),
+        normal(NormalAction::OpenEditor),
+        normal(NormalAction::CenterActive),
+        normal(NormalAction::ToggleLineWrap),
+        normal(NormalAction::ToggleSyntax),
+        normal(NormalAction::ToggleStepping),
+        normal(NormalAction::ToggleStrikethrough),
+        paired(
+            &normal,
+            NormalAction::ToggleAutoplay,
+            NormalAction::ToggleAutoplayReverse,
+        ),
+        paired(
+            &normal,
+            NormalAction::IncreaseSpeed,
+            NormalAction::DecreaseSpeed,
+        ),
+        normal(NormalAction::ToggleAnimation),
+        normal(NormalAction::ToggleViewMode),
+        normal(NormalAction::ToggleZen),
+        normal(NormalAction::ReplayStep),
+        normal(NormalAction::OpenCommandPalette),
+        normal(NormalAction::OpenFileSearch),
+        help(HelpAction::Close),
+        normal(NormalAction::Quit),
     ];
     if app.is_multi_file() {
-        help_keys.extend_from_slice(&["[ / ]", "f", "Enter", "j / k / ↑↓", "/", "r"]);
+        help_keys.extend([
+            paired(&normal, NormalAction::PrevFile, NormalAction::NextFile),
+            normal(NormalAction::ToggleFilePanel),
+            normal(NormalAction::ToggleFileListFocus),
+            paired(&normal, NormalAction::StepDown, NormalAction::StepUp),
+            normal(NormalAction::OpenSearchOrFileFilter),
+        ]);
     }
 
     let content_width = popup_width.saturating_sub(2) as usize;
@@ -1914,78 +1974,274 @@ fn draw_help_popover(frame: &mut Frame, app: &mut App) {
     };
 
     let mut lines = vec![Line::from(Span::styled(" Navigation", section_style))];
-    push_help_line(&mut lines, "j / k / ↑↓", "Step forward/back");
-    push_help_line(&mut lines, "h / l / ←→", "Prev/next hunk");
-    push_help_line(&mut lines, "b / e", "Hunk begin/end");
-    push_help_line(&mut lines, "g b", "Blame (step)");
-    push_help_line(&mut lines, "p", "Peek change");
-    push_help_line(&mut lines, "P", "Peek old hunk");
-    push_help_line(&mut lines, "y / Y", "Yank line/hunk");
-    push_help_line(&mut lines, "g y / g Y", "Copy patch (line/hunk)");
-    push_help_line(&mut lines, "/", "Search (diff pane)");
-    push_help_line(&mut lines, "n / N", "Next/prev match");
-    push_help_line(&mut lines, "c / C", "Next/prev conflict");
-    push_help_line(&mut lines, "m / M", "Add/update line/hunk comment");
-    push_help_line(&mut lines, "x / X", "Remove line/hunk comment");
-    push_help_line(&mut lines, "Ctrl+x", "Clear all comments");
+    push_help_line(
+        &mut lines,
+        &paired(&normal, NormalAction::StepDown, NormalAction::StepUp),
+        "Step forward/back",
+    );
+    push_help_line(
+        &mut lines,
+        &paired(&normal, NormalAction::PrevHunk, NormalAction::NextHunk),
+        "Prev/next hunk",
+    );
+    push_help_line(
+        &mut lines,
+        &paired(&normal, NormalAction::HunkStart, NormalAction::HunkEnd),
+        "Hunk begin/end",
+    );
+    push_help_line(&mut lines, &normal(NormalAction::BlameHint), "Blame (step)");
+    push_help_line(
+        &mut lines,
+        &normal(NormalAction::TogglePeekChange),
+        "Peek change",
+    );
+    push_help_line(
+        &mut lines,
+        &normal(NormalAction::TogglePeekHunk),
+        "Peek old hunk",
+    );
+    push_help_line(
+        &mut lines,
+        &paired(&normal, NormalAction::YankChange, NormalAction::YankHunk),
+        "Yank line/hunk",
+    );
+    push_help_line(
+        &mut lines,
+        &paired(
+            &normal,
+            NormalAction::YankChangePatch,
+            NormalAction::YankHunkPatch,
+        ),
+        "Copy patch (line/hunk)",
+    );
+    push_help_line(
+        &mut lines,
+        &normal(NormalAction::OpenSearchOrFileFilter),
+        "Search (diff pane)",
+    );
+    push_help_line(
+        &mut lines,
+        &paired(&normal, NormalAction::SearchNext, NormalAction::SearchPrev),
+        "Next/prev match",
+    );
+    push_help_line(
+        &mut lines,
+        &paired(
+            &normal,
+            NormalAction::NextConflict,
+            NormalAction::PrevConflict,
+        ),
+        "Next/prev conflict",
+    );
+    push_help_line(
+        &mut lines,
+        &paired(
+            &normal,
+            NormalAction::LineComment,
+            NormalAction::HunkComment,
+        ),
+        "Add/update line/hunk comment",
+    );
+    push_help_line(
+        &mut lines,
+        &paired(
+            &normal,
+            NormalAction::RemoveLineComment,
+            NormalAction::RemoveHunkComment,
+        ),
+        "Remove line/hunk comment",
+    );
+    push_help_line(
+        &mut lines,
+        &normal(NormalAction::ClearComments),
+        "Clear all comments",
+    );
     push_help_line(&mut lines, ":<line>", "Go to line");
     push_help_line(&mut lines, ":h<num>", "Go to hunk");
     push_help_line(&mut lines, ":s<num>", "Go to step");
-    push_help_line(&mut lines, "< / >", "First/last step (or hunk in no-step)");
-    push_help_line(&mut lines, "gg / G", "Go to start/end");
-    push_help_line(&mut lines, "J / K", "Scroll up/down");
-    push_help_line(&mut lines, "H / L", "Scroll left/right");
-    push_help_line(&mut lines, "0 / $", "Scroll to line start/end");
-    push_help_line(&mut lines, "^U / ^D", "Scroll half-page");
-    push_help_line(&mut lines, "^G", "Show full file path");
-    push_help_line(&mut lines, "o / Ctrl+e", "Open file in editor");
-    push_help_line(&mut lines, "z", "Center on active");
-    push_help_line(&mut lines, "w", "Toggle line wrap");
-    push_help_line(&mut lines, "f", "Toggle context folding");
-    push_help_line(&mut lines, "t", "Toggle syntax highlight");
-    if app.view_mode == ViewMode::Evolution {
-        push_help_line(&mut lines, "E", "Toggle evo syntax (context/full)");
-    }
-    push_help_line(&mut lines, "s", "Toggle stepping");
-    push_help_line(&mut lines, "S", "Toggle strikethrough");
-    push_help_line(&mut lines, "Ctrl+P", "Command palette");
-    push_help_line(&mut lines, "Ctrl+Shift+P", "Quick file search");
-    lines.push(Line::from(""));
-    lines.push(Line::from(Span::styled(" Playback", section_style)));
-    push_help_line(&mut lines, "Space / B", "Autoplay forward/reverse");
-    push_help_line(&mut lines, "r", "Replay last step");
-    push_help_line(&mut lines, "nr", "Replay last n steps");
     push_help_line(
         &mut lines,
-        "+ / -",
+        &paired(&normal, NormalAction::FirstStep, NormalAction::LastStep),
+        "First/last step (or hunk in no-step)",
+    );
+    push_help_line(
+        &mut lines,
+        &paired(&normal, NormalAction::GotoStart, NormalAction::GotoEnd),
+        "Go to start/end",
+    );
+    push_help_line(
+        &mut lines,
+        &paired(&normal, NormalAction::ScrollDown, NormalAction::ScrollUp),
+        "Scroll up/down",
+    );
+    push_help_line(
+        &mut lines,
+        &paired(&normal, NormalAction::ScrollLeft, NormalAction::ScrollRight),
+        "Scroll left/right",
+    );
+    push_help_line(
+        &mut lines,
+        &paired(&normal, NormalAction::LineStart, NormalAction::LineEnd),
+        "Scroll to line start/end",
+    );
+    push_help_line(
+        &mut lines,
+        &paired(
+            &normal,
+            NormalAction::HalfPageUp,
+            NormalAction::HalfPageDown,
+        ),
+        "Scroll half-page",
+    );
+    push_help_line(
+        &mut lines,
+        &normal(NormalAction::TogglePathPopup),
+        "Show full file path",
+    );
+    push_help_line(
+        &mut lines,
+        &normal(NormalAction::OpenEditor),
+        "Open file in editor",
+    );
+    push_help_line(
+        &mut lines,
+        &normal(NormalAction::CenterActive),
+        "Center on active",
+    );
+    push_help_line(
+        &mut lines,
+        &normal(NormalAction::ToggleLineWrap),
+        "Toggle line wrap",
+    );
+    push_help_line(
+        &mut lines,
+        &normal(NormalAction::ToggleFoldContext),
+        "Toggle context folding",
+    );
+    push_help_line(
+        &mut lines,
+        &normal(NormalAction::ToggleSyntax),
+        "Toggle syntax highlight",
+    );
+    if app.view_mode == ViewMode::Evolution {
+        push_help_line(
+            &mut lines,
+            &normal(NormalAction::ToggleEvoSyntax),
+            "Toggle evo syntax (context/full)",
+        );
+    }
+    push_help_line(
+        &mut lines,
+        &normal(NormalAction::ToggleStepping),
+        "Toggle stepping",
+    );
+    push_help_line(
+        &mut lines,
+        &normal(NormalAction::ToggleStrikethrough),
+        "Toggle strikethrough",
+    );
+    push_help_line(
+        &mut lines,
+        &normal(NormalAction::OpenCommandPalette),
+        "Command palette",
+    );
+    push_help_line(
+        &mut lines,
+        &normal(NormalAction::OpenFileSearch),
+        "Quick file search",
+    );
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(" Playback", section_style)));
+    push_help_line(
+        &mut lines,
+        &paired(
+            &normal,
+            NormalAction::ToggleAutoplay,
+            NormalAction::ToggleAutoplayReverse,
+        ),
+        "Autoplay forward/reverse",
+    );
+    push_help_line(
+        &mut lines,
+        &normal(NormalAction::ReplayStep),
+        "Replay last step",
+    );
+    push_help_line(
+        &mut lines,
+        &counted_binding_label(&normal(NormalAction::ReplayStep)),
+        "Replay last n steps",
+    );
+    push_help_line(
+        &mut lines,
+        &paired(
+            &normal,
+            NormalAction::IncreaseSpeed,
+            NormalAction::DecreaseSpeed,
+        ),
         &format!("Speed ({}ms)", app.animation_speed),
     );
-    push_help_line(&mut lines, "a", "Toggle animation");
+    push_help_line(
+        &mut lines,
+        &normal(NormalAction::ToggleAnimation),
+        "Toggle animation",
+    );
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(" View", section_style)));
-    push_help_line(&mut lines, "Tab", "Cycle view mode");
-    push_help_line(&mut lines, "Shift-Tab", "Cycle view mode (reverse)");
-    push_help_line(&mut lines, "Z", "Zen mode");
-    push_help_line(&mut lines, "R", "Refresh all files");
+    push_help_line(
+        &mut lines,
+        &normal(NormalAction::ToggleViewMode),
+        "Cycle view mode",
+    );
+    push_help_line(
+        &mut lines,
+        &normal(NormalAction::ToggleViewModeReverse),
+        "Cycle view mode (reverse)",
+    );
+    push_help_line(&mut lines, &normal(NormalAction::ToggleZen), "Zen mode");
+    push_help_line(
+        &mut lines,
+        &normal(NormalAction::Refresh),
+        "Refresh all files",
+    );
 
     if app.is_multi_file() {
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(" Files", section_style)));
-        push_help_line(&mut lines, "[ / ]", "Prev/next file");
-        push_help_line(&mut lines, "Ctrl+F", "Toggle file panel");
-        push_help_line(&mut lines, "Enter", "Focus file list");
-        push_help_line(&mut lines, "j / k / ↑↓", "Move selection (focused)");
-        push_help_line(&mut lines, "/", "Filter files (when focused)");
+        push_help_line(
+            &mut lines,
+            &paired(&normal, NormalAction::PrevFile, NormalAction::NextFile),
+            "Prev/next file",
+        );
+        push_help_line(
+            &mut lines,
+            &normal(NormalAction::ToggleFilePanel),
+            "Toggle file panel",
+        );
+        push_help_line(
+            &mut lines,
+            &normal(NormalAction::ToggleFileListFocus),
+            "Focus file list",
+        );
+        push_help_line(
+            &mut lines,
+            &paired(&normal, NormalAction::StepDown, NormalAction::StepUp),
+            "Move selection (focused)",
+        );
+        push_help_line(
+            &mut lines,
+            &normal(NormalAction::OpenSearchOrFileFilter),
+            "Filter files (when focused)",
+        );
     }
 
     lines.push(Line::from(""));
     lines.push(Line::from(vec![
-        Span::styled(format!("  {:<12}", "?"), key_style),
+        Span::styled(format!("  {:<12}", help(HelpAction::Close)), key_style),
         Span::styled("Close help", dim_style),
     ]));
     let quit_label = "Quit (prints comments if any)";
     lines.push(Line::from(vec![
-        Span::styled(format!("  {:<12}", "q / Esc"), key_style),
+        Span::styled(format!("  {:<12}", normal(NormalAction::Quit)), key_style),
         Span::styled(quit_label, label_style),
     ]));
 
@@ -2302,4 +2558,19 @@ fn draw_file_search_popover(frame: &mut Frame, app: &mut App) {
     }
     let list = List::new(items).highlight_style(highlight_style);
     frame.render_stateful_widget(list, chunks[1], &mut state);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::counted_binding_label;
+
+    #[test]
+    fn counted_binding_label_uses_current_binding() {
+        assert_eq!(counted_binding_label("r"), "<count>r");
+        assert_eq!(counted_binding_label("g r"), "<count>g r");
+        assert_eq!(
+            counted_binding_label("r / ctrl-r"),
+            "<count>r / <count>ctrl-r"
+        );
+    }
 }

--- a/docs/DIFF_VIEWER.md
+++ b/docs/DIFF_VIEWER.md
@@ -15,6 +15,9 @@ and avoids implementation details.
 
 ## Navigation & Stepping
 
+Key examples below are default bindings. Users can override them through
+`[keybindings.<mode>]` in `config.toml`.
+
 - **Step forward/back** (`j` / `k`): apply/unapply the next/previous change.
 - **Hunk jump** (`h` / `l`, `:h<num>`): jump to previous/next hunk.
   - Entering a hunk via hunk jump shows a **full preview** of that hunk.


### PR DESCRIPTION
Route keyboard handling through typed keybinding modes backed by keymap-rs. Add snake_case [keybindings.<mode>] overrides, sequence buffering, dynamic help/hint labels, and dashboard picker coverage.

I am really sorry for the size of this PR, but considering what it is replacing I didn't find it particularly valuable to do it piecemeal. The current keybindings are all hardcoded in the main switch so I thought a big bang replacement was the easiest.

I have split this up in a few commits to make it easier to review if that helps, I am also happy to just drop this if you're not interested, or let this serve as a feature request if you'd rather implement it in a different way.