### PR TITLE
fix: add global keybindings for palette shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,8 +374,14 @@ open_at_line = true          # Used when args is omitted
 file_scope = "repo"         # "changed" | "repo" (git-aware via ls-files)
 finder = "auto"             # "auto" | "builtin" | "fzf"
 
+[keybindings.global]
+# Checked before text input modes, except help and review editor.
+open_command_palette = ["ctrl-p"]
+open_file_search = ["ctrl-shift-p"]
+
 [keybindings.normal]
 # Omitted actions keep defaults. An empty array unbinds the action.
+# Unmodified 1-9 are reserved for counts.
 step_down = ["j", "down"]
 step_up = ["k", "up"]
 goto_start = ["g g", "home"]
@@ -433,6 +439,9 @@ autoplay = false
 [comments.mentions]
 file_scope = "repo"
 finder = "auto"
+
+[keybindings.global]
+open_command_palette = ["ctrl-o"]
 
 [keybindings.normal]
 step_down = ["o"] # replaces the default j/down binding

--- a/crates/oyo/src/config.rs
+++ b/crates/oyo/src/config.rs
@@ -60,7 +60,12 @@
 //! # args = ["+{line}", "{file}"]
 //! open_at_line = true
 //!
+//! [keybindings.global]
+//! open_command_palette = ["ctrl-p"]
+//! open_file_search = ["ctrl-shift-p"]
+//!
 //! [keybindings.normal]
+//! # Unmodified 1-9 are reserved for counts.
 //! step_down = ["j", "down"]
 //! step_up = ["k", "up"]
 //! goto_start = ["g g", "home"]

--- a/crates/oyo/src/input.rs
+++ b/crates/oyo/src/input.rs
@@ -1,8 +1,8 @@
 use crate::app::{App, ViewMode};
 use crate::config;
 use crate::keybindings::{
-    Dispatch, FileFilterAction, HelpAction, LineInputAction, NormalAction, PickerAction,
-    ReviewEditorAction,
+    Dispatch, FileFilterAction, GlobalAction, HelpAction, LineInputAction, NormalAction,
+    PickerAction, ReviewEditorAction,
 };
 use anyhow::Result;
 use crossterm::{
@@ -26,6 +26,10 @@ pub(crate) fn handle_app_key(
 
     if app.review_editor_active() {
         handle_review_editor_key(app, key);
+        return Ok(());
+    }
+
+    if handle_global_key(app, key) {
         return Ok(());
     }
 
@@ -55,6 +59,31 @@ pub(crate) fn handle_app_key(
     }
 
     handle_normal_key(app, key, pending_event, terminal, editor_config)
+}
+
+fn handle_global_key(app: &mut App, key: KeyEvent) -> bool {
+    match app.keybindings.global(key) {
+        Dispatch::Matched(GlobalAction::OpenCommandPalette) => {
+            app.reset_count();
+            if app.command_palette_active() {
+                app.stop_command_palette();
+            } else {
+                app.start_command_palette();
+            }
+            true
+        }
+        Dispatch::Matched(GlobalAction::OpenFileSearch) => {
+            app.reset_count();
+            if app.file_search_active() {
+                app.stop_file_search();
+            } else {
+                app.start_file_search();
+            }
+            true
+        }
+        Dispatch::Pending => true,
+        Dispatch::Unmatched => false,
+    }
 }
 
 fn printable_char(key: KeyEvent) -> Option<char> {
@@ -242,6 +271,20 @@ fn handle_search_key(app: &mut App, key: KeyEvent) {
     }
 }
 
+fn count_digit(key: KeyEvent, pending_count: bool) -> Option<u8> {
+    if !key.modifiers.is_empty() {
+        return None;
+    }
+    let KeyCode::Char(c @ '0'..='9') = key.code else {
+        return None;
+    };
+    if c != '0' || pending_count {
+        Some(c as u8 - b'0')
+    } else {
+        None
+    }
+}
+
 fn repeat_count(
     app: &mut App,
     key: KeyEvent,
@@ -264,11 +307,9 @@ fn handle_normal_key(
     terminal: &mut TuiTerminal,
     editor_config: &config::EditorConfig,
 ) -> Result<()> {
-    if matches!(key.code, KeyCode::Char(c @ '0'..='9') if c != '0' || app.pending_count.is_some()) {
-        if let KeyCode::Char(c) = key.code {
-            app.keybindings.clear_sequence();
-            app.push_count_digit(c as u8 - b'0');
-        }
+    if let Some(digit) = count_digit(key, app.pending_count.is_some()) {
+        app.keybindings.clear_sequence();
+        app.push_count_digit(digit);
         return Ok(());
     }
 
@@ -665,4 +706,42 @@ fn dispatch_normal_action(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oyo_core::MultiFileDiff;
+
+    fn key(ch: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(ch), KeyModifiers::empty())
+    }
+
+    fn ctrl(ch: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(ch), KeyModifiers::CONTROL)
+    }
+
+    #[test]
+    fn global_palette_binding_opens_from_search_mode() {
+        let diff = MultiFileDiff::from_file_pair(
+            "old.txt".into(),
+            "new.txt".into(),
+            "old\n".to_string(),
+            "new\n".to_string(),
+        );
+        let mut app = App::new(diff, ViewMode::UnifiedPane, 0, false, None);
+        app.start_search();
+
+        assert!(handle_global_key(&mut app, ctrl('p')));
+        assert!(app.command_palette_active());
+        assert!(!app.search_active());
+    }
+
+    #[test]
+    fn count_digits_require_plain_digit_keys() {
+        assert_eq!(count_digit(key('1'), false), Some(1));
+        assert_eq!(count_digit(key('0'), false), None);
+        assert_eq!(count_digit(key('0'), true), Some(0));
+        assert_eq!(count_digit(ctrl('1'), false), None);
+    }
 }

--- a/crates/oyo/src/keybindings.rs
+++ b/crates/oyo/src/keybindings.rs
@@ -6,6 +6,7 @@ use std::hash::Hash;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum KeybindingMode {
+    Global,
     Normal,
     Help,
     ReviewEditor,
@@ -21,6 +22,7 @@ pub(crate) enum KeybindingMode {
 impl KeybindingMode {
     fn id(self) -> &'static str {
         match self {
+            Self::Global => "global",
             Self::Normal => "normal",
             Self::Help => "help",
             Self::ReviewEditor => "review_editor",
@@ -33,6 +35,12 @@ impl KeybindingMode {
             Self::DashboardFilter => "dashboard_filter",
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum GlobalAction {
+    OpenCommandPalette,
+    OpenFileSearch,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -217,6 +225,11 @@ macro_rules! binding_action {
     };
 }
 
+binding_action!(GlobalAction, [
+    OpenCommandPalette => ("open_command_palette", "Command palette", ["ctrl-p"]),
+    OpenFileSearch => ("open_file_search", "Quick file search", ["ctrl-shift-p"]),
+]);
+
 binding_action!(NormalAction, [
     Quit => ("quit", "Quit (prints comments if any)", ["q", "esc"]),
     StepDown => ("step_down", "Step forward", ["j", "down"]),
@@ -358,6 +371,7 @@ binding_action!(DashboardFilterAction, [
 
 #[derive(Debug)]
 pub(crate) struct Keybindings {
+    global: ModeBindings<GlobalAction>,
     normal: ModeBindings<NormalAction>,
     help: ModeBindings<HelpAction>,
     review_editor: ModeBindings<ReviewEditorAction>,
@@ -405,6 +419,7 @@ impl Keybindings {
     ) -> Self {
         warn_unknown_modes(config, warnings);
         Self {
+            global: ModeBindings::build(KeybindingMode::Global, config, warnings),
             normal: ModeBindings::build(KeybindingMode::Normal, config, warnings),
             help: ModeBindings::build(KeybindingMode::Help, config, warnings),
             review_editor: ModeBindings::build(KeybindingMode::ReviewEditor, config, warnings),
@@ -425,6 +440,7 @@ impl Keybindings {
 
     pub(crate) fn clear_sequence(&mut self) {
         match self.active_sequence_mode.take() {
+            Some(KeybindingMode::Global) => self.global.clear_sequence(),
             Some(KeybindingMode::Normal) => self.normal.clear_sequence(),
             Some(KeybindingMode::Help) => self.help.clear_sequence(),
             Some(KeybindingMode::ReviewEditor) => self.review_editor.clear_sequence(),
@@ -437,6 +453,11 @@ impl Keybindings {
             Some(KeybindingMode::DashboardFilter) => self.dashboard_filter.clear_sequence(),
             None => {}
         }
+    }
+
+    pub(crate) fn global(&mut self, key: KeyEvent) -> Dispatch<GlobalAction> {
+        self.prepare_mode(KeybindingMode::Global);
+        dispatch_mode(&mut self.active_sequence_mode, &mut self.global, key)
     }
 
     pub(crate) fn normal(&mut self, key: KeyEvent) -> Dispatch<NormalAction> {
@@ -495,6 +516,10 @@ impl Keybindings {
             &mut self.dashboard_filter,
             key,
         )
+    }
+
+    pub(crate) fn global_keys(&self, action: GlobalAction) -> String {
+        self.global.keys_label(action)
     }
 
     pub(crate) fn normal_keys(&self, action: NormalAction) -> String {
@@ -556,7 +581,14 @@ impl<A: BindingAction + 'static> ModeBindings<A> {
             }
         }
 
-        if let Err(error) = validate_effective_bindings::<A>(&effective) {
+        let validation = validate_effective_bindings::<A>(&effective).and_then(|_| {
+            if mode == KeybindingMode::Normal {
+                validate_normal_count_bindings(&effective)
+            } else {
+                Ok(())
+            }
+        });
+        if let Err(error) = validation {
             warnings.push(format!(
                 "Ignoring [keybindings.{}]: {}; using defaults for this mode",
                 mode.id(),
@@ -630,6 +662,7 @@ impl<A: BindingAction + 'static> ModeBindings<A> {
 fn warn_unknown_modes(config: &KeybindingsConfig, warnings: &mut Vec<String>) {
     for mode in config.modes.keys() {
         if ![
+            KeybindingMode::Global.id(),
             KeybindingMode::Normal.id(),
             KeybindingMode::Help.id(),
             KeybindingMode::ReviewEditor.id(),
@@ -694,6 +727,25 @@ fn validate_effective_bindings<A: BindingAction + 'static>(
                 ));
             }
             seen.push((parsed, id, key.clone()));
+        }
+    }
+    Ok(())
+}
+
+fn validate_normal_count_bindings(
+    bindings: &BTreeMap<&'static str, Vec<String>>,
+) -> Result<(), String> {
+    for (id, keys) in bindings {
+        for key in keys {
+            if let Some(token) = key
+                .split_whitespace()
+                .find(|token| matches!(*token, "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"))
+            {
+                return Err(format!(
+                    "key '{}' for '{}' uses reserved count digit '{}'",
+                    key, id, token
+                ));
+            }
         }
     }
     Ok(())
@@ -853,6 +905,49 @@ mod tests {
     }
 
     #[test]
+    fn global_palette_bindings_are_configurable() {
+        let config = KeybindingsConfig {
+            modes: BTreeMap::from([(
+                "global".to_string(),
+                BTreeMap::from([(
+                    "open_command_palette".to_string(),
+                    vec!["ctrl-o".to_string()],
+                )]),
+            )]),
+        };
+        let mut warnings = Vec::new();
+        let mut bindings = Keybindings::from_config_with_warnings(&config, &mut warnings);
+
+        assert!(warnings.is_empty(), "{warnings:?}");
+        assert_eq!(
+            bindings.global(ctrl('o')),
+            Dispatch::Matched(GlobalAction::OpenCommandPalette)
+        );
+        assert_eq!(bindings.global(ctrl('p')), Dispatch::Unmatched);
+    }
+
+    #[test]
+    fn normal_digit_binding_falls_back_to_defaults() {
+        let config = KeybindingsConfig {
+            modes: BTreeMap::from([(
+                "normal".to_string(),
+                BTreeMap::from([("step_down".to_string(), vec!["1".to_string()])]),
+            )]),
+        };
+        let mut warnings = Vec::new();
+        let mut bindings = Keybindings::from_config_with_warnings(&config, &mut warnings);
+
+        assert!(warnings
+            .iter()
+            .any(|warning| warning.contains("reserved count digit")));
+        assert_eq!(
+            bindings.normal(key('j')),
+            Dispatch::Matched(NormalAction::StepDown)
+        );
+        assert_eq!(bindings.normal(key('1')), Dispatch::Unmatched);
+    }
+
+    #[test]
     fn ctrl_shift_binding_matches_configured_default() {
         let mut bindings = Keybindings::default();
         let key = KeyEvent::new(
@@ -861,8 +956,20 @@ mod tests {
         );
 
         assert_eq!(
+            bindings.global(key),
+            Dispatch::Matched(GlobalAction::OpenFileSearch)
+        );
+        let key = KeyEvent::new(
+            KeyCode::Char('p'),
+            KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+        );
+        assert_eq!(
             bindings.normal(key),
             Dispatch::Matched(NormalAction::OpenFileSearch)
+        );
+        assert_eq!(
+            bindings.global(ctrl('p')),
+            Dispatch::Matched(GlobalAction::OpenCommandPalette)
         );
         assert_eq!(
             bindings.normal(ctrl('p')),

--- a/crates/oyo/src/ui.rs
+++ b/crates/oyo/src/ui.rs
@@ -2,7 +2,7 @@
 
 use crate::app::{App, ViewMode, DIFF_VIEW_MIN_WIDTH, FILE_PANEL_MIN_WIDTH};
 use crate::color;
-use crate::keybindings::{HelpAction, NormalAction, ReviewEditorAction};
+use crate::keybindings::{GlobalAction, HelpAction, NormalAction, ReviewEditorAction};
 use crate::views::{render_blame, render_evolution, render_split, render_unified_pane};
 use oyo_core::{multi::DiffStatus, FileStatus};
 use ratatui::{
@@ -1766,6 +1766,7 @@ fn draw_help_popover(frame: &mut Frame, app: &mut App) {
     let dim_style = Style::default().fg(app.theme.text_muted);
     let section_style = Style::default().fg(app.theme.primary);
 
+    let global = |action| app.keybindings.global_keys(action);
     let normal = |action| app.keybindings.normal_keys(action);
     let help = |action| app.keybindings.help_keys(action);
     let mut help_keys = vec![
@@ -1830,8 +1831,8 @@ fn draw_help_popover(frame: &mut Frame, app: &mut App) {
         normal(NormalAction::ToggleViewMode),
         normal(NormalAction::ToggleZen),
         normal(NormalAction::ReplayStep),
-        normal(NormalAction::OpenCommandPalette),
-        normal(NormalAction::OpenFileSearch),
+        global(GlobalAction::OpenCommandPalette),
+        global(GlobalAction::OpenFileSearch),
         help(HelpAction::Close),
         normal(NormalAction::Quit),
     ];
@@ -2142,12 +2143,12 @@ fn draw_help_popover(frame: &mut Frame, app: &mut App) {
     );
     push_help_line(
         &mut lines,
-        &normal(NormalAction::OpenCommandPalette),
+        &global(GlobalAction::OpenCommandPalette),
         "Command palette",
     );
     push_help_line(
         &mut lines,
-        &normal(NormalAction::OpenFileSearch),
+        &global(GlobalAction::OpenFileSearch),
         "Quick file search",
     );
     lines.push(Line::from(""));

--- a/docs/DIFF_VIEWER.md
+++ b/docs/DIFF_VIEWER.md
@@ -16,7 +16,7 @@ and avoids implementation details.
 ## Navigation & Stepping
 
 Key examples below are default bindings. Users can override them through
-`[keybindings.<mode>]` in `config.toml`.
+`[keybindings.<mode>]` in `config.toml`; global shortcuts use `[keybindings.global]`.
 
 - **Step forward/back** (`j` / `k`): apply/unapply the next/previous change.
 - **Hunk jump** (`h` / `l`, `:h<num>`): jump to previous/next hunk.


### PR DESCRIPTION
Add `keybindings.global` for palette and file search shortcuts so they work across input modes. Warn on normal bindings that use reserved count digits.