### PR TITLE
fix: reduce idle TUI redraws

### DIFF
--- a/crates/oyo/src/app/diff_worker.rs
+++ b/crates/oyo/src/app/diff_worker.rs
@@ -32,39 +32,40 @@ impl App {
         self.diff_worker_rx = Some(resp_rx);
     }
 
-    pub(crate) fn queue_diff_for_file(&mut self, idx: usize) {
+    pub(crate) fn queue_diff_for_file(&mut self, idx: usize) -> bool {
         if !self.diff_defer {
-            return;
+            return false;
         }
         if !matches!(
             self.multi_diff.diff_status(idx),
             oyo_core::multi::DiffStatus::Deferred
         ) {
-            return;
+            return false;
         }
         if self.diff_inflight == Some(idx) || self.diff_queue.contains(&idx) {
-            return;
+            return false;
         }
         self.diff_queue.push_back(idx);
-        self.start_next_diff_job();
+        let _ = self.start_next_diff_job();
+        true
     }
 
-    pub(crate) fn queue_current_file_diff(&mut self) {
+    pub(crate) fn queue_current_file_diff(&mut self) -> bool {
         let idx = self.multi_diff.selected_index;
-        self.queue_diff_for_file(idx);
+        self.queue_diff_for_file(idx)
     }
 
-    fn start_next_diff_job(&mut self) {
+    fn start_next_diff_job(&mut self) -> bool {
         if self.diff_inflight.is_some() {
-            return;
+            return false;
         }
         let Some(idx) = self.diff_queue.pop_front() else {
-            return;
+            return false;
         };
         self.ensure_diff_worker();
         let (old, new) = match self.multi_diff.file_contents_arc(idx) {
             Some((old, new)) => (old, new),
-            None => return,
+            None => return false,
         };
         if let Some(tx) = self.diff_worker_tx.as_ref() {
             self.multi_diff.mark_diff_computing(idx);
@@ -77,17 +78,20 @@ impl App {
             if tx.send(request).is_err() {
                 self.diff_inflight = None;
             }
+            return true;
         }
+        false
     }
 
-    pub(crate) fn poll_diff_responses(&mut self) {
+    pub(crate) fn poll_diff_responses(&mut self) -> bool {
         let Some(rx) = self.diff_worker_rx.as_mut() else {
-            return;
+            return false;
         };
         let mut responses = Vec::new();
         while let Ok(resp) = rx.try_recv() {
             responses.push(resp);
         }
+        let changed = !responses.is_empty();
         for resp in responses {
             if self.diff_inflight == Some(resp.file_index) {
                 self.diff_inflight = None;
@@ -112,28 +116,29 @@ impl App {
                 }
             }
         }
-        self.start_next_diff_job();
+        let started = self.start_next_diff_job();
+        changed || started
     }
 
-    pub(crate) fn maybe_queue_idle_diff(&mut self) {
+    pub(crate) fn maybe_queue_idle_diff(&mut self) -> bool {
         if !self.diff_defer || self.diff_inflight.is_some() {
-            return;
+            return false;
         }
         if !self.diff_queue.is_empty() {
-            return;
+            return false;
         }
         let idle = self.diff_last_input.elapsed().as_millis();
         if idle < self.diff_idle_ms as u128 {
-            return;
+            return false;
         }
         for idx in 0..self.multi_diff.file_count() {
             if matches!(
                 self.multi_diff.diff_status(idx),
                 oyo_core::multi::DiffStatus::Deferred
             ) {
-                self.queue_diff_for_file(idx);
-                break;
+                return self.queue_diff_for_file(idx);
             }
         }
+        false
     }
 }

--- a/crates/oyo/src/app/files.rs
+++ b/crates/oyo/src/app/files.rs
@@ -354,7 +354,9 @@ impl App {
         }
     }
 
-    fn recompute_file_change_state(&mut self) {
+    fn recompute_file_change_state(&mut self) -> bool {
+        let old_any = self.files_changed_on_disk;
+        let old_changed = self.file_disk_changed.clone();
         let file_count = self.multi_diff.file_count();
         if self.file_disk_baseline.len() != file_count {
             self.rebuild_file_disk_baseline();
@@ -372,6 +374,7 @@ impl App {
             any_changed |= changed;
         }
         self.files_changed_on_disk = any_changed;
+        old_any != self.files_changed_on_disk || old_changed != self.file_disk_changed
     }
 
     pub(crate) fn file_changed_on_disk(&self, idx: usize) -> bool {
@@ -379,13 +382,13 @@ impl App {
     }
 
     /// Check if tracked files changed on disk since the last refresh baseline.
-    pub fn maybe_check_file_changes(&mut self) {
+    pub fn maybe_check_file_changes(&mut self) -> bool {
         let now = Instant::now();
         if now.duration_since(self.last_fs_check) < Duration::from_secs(1) {
-            return;
+            return false;
         }
         self.last_fs_check = now;
-        self.recompute_file_change_state();
+        self.recompute_file_change_state()
     }
 
     /// Refresh current file from disk

--- a/crates/oyo/src/app/mod.rs
+++ b/crates/oyo/src/app/mod.rs
@@ -1612,26 +1612,46 @@ impl App {
         self.center_with_display_idx(viewport_height, total_len, global_idx);
     }
 
-    /// Called every frame to update animations and autoplay
-    pub fn tick(&mut self) {
+    pub fn redraw_interval(&self) -> Duration {
+        if self.animation_phase != AnimationPhase::Idle || self.snap_frame.is_some() {
+            Duration::from_millis(33)
+        } else if self.autoplay
+            || self.diff_inflight.is_some()
+            || !self.diff_queue.is_empty()
+            || self.syntax_warmup_pending()
+            || self.step_edge_hint.is_some()
+            || self.hunk_edge_hint.is_some()
+        {
+            Duration::from_millis(100)
+        } else {
+            Duration::from_millis(250)
+        }
+    }
+
+    /// Update animations and background work. Returns true when the UI changed.
+    pub fn tick(&mut self) -> bool {
         let now = Instant::now();
+        let mut dirty = false;
 
         if let Some(hint) = self.step_edge_hint {
             if now >= hint.until {
                 self.step_edge_hint = None;
+                dirty = true;
             }
         }
         if let Some(hint) = self.hunk_edge_hint {
             if now >= hint.until {
                 self.hunk_edge_hint = None;
+                dirty = true;
             }
         }
 
-        self.poll_diff_responses();
-        self.maybe_queue_idle_diff();
-        self.maybe_check_file_changes();
+        dirty |= self.poll_diff_responses();
+        dirty |= self.maybe_queue_idle_diff();
+        dirty |= self.maybe_check_file_changes();
 
         if let Some(frame) = self.snap_frame {
+            dirty = true;
             let started_at = self.snap_frame_started_at.get_or_insert(now);
             let phase_duration = Duration::from_millis(SNAP_PHASE_MS);
             if now.duration_since(*started_at) >= phase_duration {
@@ -1654,6 +1674,7 @@ impl App {
 
         // Update animation
         if self.animation_phase != AnimationPhase::Idle {
+            dirty = true;
             let elapsed = now.duration_since(self.last_animation_tick);
             let phase_duration = Duration::from_millis(self.animation_duration);
 
@@ -1687,6 +1708,7 @@ impl App {
         if self.stepping && self.autoplay && self.animation_phase == AnimationPhase::Idle {
             let autoplay_interval = Duration::from_millis(self.animation_speed * 2);
             if now.duration_since(self.last_autoplay_tick) >= autoplay_interval {
+                dirty = true;
                 let moved = if self.autoplay_reverse {
                     self.step_backward()
                 } else {
@@ -1707,7 +1729,8 @@ impl App {
             }
         }
 
-        self.maybe_warm_syntax_cache();
+        dirty |= self.maybe_warm_syntax_cache();
+        dirty
     }
 }
 

--- a/crates/oyo/src/app/syntax.rs
+++ b/crates/oyo/src/app/syntax.rs
@@ -54,12 +54,12 @@ impl App {
         cache.rendered_spans(side, line_num - 1)
     }
 
-    pub(crate) fn maybe_warm_syntax_cache(&mut self) {
+    pub(crate) fn maybe_warm_syntax_cache(&mut self) -> bool {
         if !self.syntax_enabled() {
-            return;
+            return false;
         }
         if self.animation_phase != AnimationPhase::Idle || self.snap_frame.is_some() {
-            return;
+            return false;
         }
         let idle = self.diff_last_input.elapsed().as_millis();
         let idle_threshold = self.diff_idle_ms as u128;
@@ -74,7 +74,7 @@ impl App {
             .map(|at| now.duration_since(at).as_millis() >= debounce as u128)
             .unwrap_or(true);
         if self.syntax_warmup_target.is_some() && !target_ready {
-            return;
+            return false;
         }
         let target = if target_ready {
             self.syntax_warmup_target
@@ -84,9 +84,9 @@ impl App {
         let target_applied = self.syntax_warmup_target_applied;
         let current_index = self.multi_diff.selected_index;
 
-        let (apply_target, clear_target) = {
+        let (apply_target, clear_target, warmed) = {
             let Some(cache) = self.ensure_syntax_cache() else {
-                return;
+                return false;
             };
 
             let mut apply_target = None;
@@ -104,7 +104,7 @@ impl App {
 
             let warm_pending = cache.warm_pending();
             if idle < idle_threshold && !warm_pending {
-                return;
+                return false;
             }
             let budget = if idle >= idle_threshold {
                 idle_lines
@@ -113,20 +113,25 @@ impl App {
             } else {
                 active_lines
             };
-            let _ = cache.warm_checkpoints(budget);
-            (apply_target, clear_target)
+            let warmed = cache.warm_checkpoints(budget) > 0;
+            (apply_target, clear_target, warmed)
         };
 
+        let mut changed = warmed;
         if clear_target {
             self.syntax_warmup_target = None;
             self.syntax_warmup_target_applied = None;
+            changed = true;
         }
         if let Some(target) = apply_target {
             self.syntax_warmup_target_applied = Some(target);
+            changed = true;
         }
         if target_ready && self.syntax_warmup_target.is_some() {
             self.syntax_warmup_target_at = None;
+            changed = true;
         }
+        changed
     }
 
     pub(crate) fn begin_syntax_warmup_frame(&mut self) {

--- a/crates/oyo/src/main.rs
+++ b/crates/oyo/src/main.rs
@@ -1379,23 +1379,30 @@ fn run_app(
     app: &mut App,
     editor_config: &config::EditorConfig,
 ) -> Result<AppExit> {
-    let tick_rate = Duration::from_millis(16);
     let mut pending_event: Option<Event> = None;
+    let mut needs_draw = true;
 
     loop {
-        terminal
-            .draw(|f| ui::draw(f, app))
-            .map_err(|e| anyhow!("{e}"))?;
+        if needs_draw {
+            terminal
+                .draw(|f| ui::draw(f, app))
+                .map_err(|e| anyhow!("{e}"))?;
+            needs_draw = false;
 
-        // Clear active change after render (one-frame extent marker display when animation disabled)
-        if app.clear_active_on_next_render {
-            app.multi_diff.current_navigator().clear_active_change();
-            app.clear_active_on_next_render = false;
+            // Clear active change after render (one-frame extent marker display when animation disabled)
+            if app.clear_active_on_next_render {
+                app.multi_diff.current_navigator().clear_active_change();
+                app.clear_active_on_next_render = false;
+                needs_draw = true;
+            }
+            if needs_draw {
+                continue;
+            }
         }
 
         let event = if let Some(event) = pending_event.take() {
             Some(event)
-        } else if event::poll(tick_rate)? {
+        } else if event::poll(app.redraw_interval())? {
             Some(event::read()?)
         } else {
             None
@@ -1403,6 +1410,7 @@ fn run_app(
 
         if let Some(event) = event {
             app.mark_user_input();
+            needs_draw = true;
             match event {
                 Event::Mouse(me) => {
                     if app.show_help || app.show_path_popup {
@@ -1491,8 +1499,9 @@ fn run_app(
             }
         }
 
-        // Handle autoplay
-        app.tick();
+        if app.tick() {
+            needs_draw = true;
+        }
 
         if app.open_dashboard {
             app.open_dashboard = false;
@@ -1532,14 +1541,19 @@ fn run_dashboard<B: Backend>(
     terminal: &mut Terminal<B>,
     dashboard: &mut Dashboard,
 ) -> Result<Option<DashboardSelection>> {
-    let tick_rate = Duration::from_millis(16);
+    let tick_rate = Duration::from_millis(250);
+    let mut needs_draw = true;
 
     loop {
-        terminal
-            .draw(|f| dashboard.draw(f))
-            .map_err(|e| anyhow!("{e}"))?;
+        if needs_draw {
+            terminal
+                .draw(|f| dashboard.draw(f))
+                .map_err(|e| anyhow!("{e}"))?;
+            needs_draw = false;
+        }
 
         if event::poll(tick_rate)? {
+            needs_draw = true;
             match event::read()? {
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
                     let list_height =


### PR DESCRIPTION
Draw only when input or background work changes UI state. Use 30 FPS while animations are active, 100 ms for background work, and 250 ms while idle; make dashboard redraw on events instead of every frame.