### PR TITLE
feat: add review hooks and actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,14 @@ open_at_line = true          # Used when args is omitted
 file_scope = "repo"         # "changed" | "repo" (git-aware via ls-files)
 finder = "auto"             # "auto" | "builtin" | "fzf"
 
+[[review.hooks]]
+# Run a command when final review output is ready. See docs/REVIEW_HOOKS.md.
+id = "review-ready"
+on = "review_ready"
+command = ".oyo/hooks/review-ready"
+stdin = "json"
+blocking = true
+
 [keybindings.global]
 # Checked before text input modes, except help and review editor.
 open_command_palette = ["ctrl-p"]
@@ -476,6 +484,7 @@ Config is loaded from (in priority order):
 
 Theme and syntax theme configuration is documented in [THEME.md](./docs/THEME.md).
 Keybinding actions are documented in [KEYBINDINGS.md](./docs/KEYBINDINGS.md).
+Review hooks are documented in [REVIEW_HOOKS.md](./docs/REVIEW_HOOKS.md).
 
 [![diff preview](./assets/ui_syntax_off.png)](./docs/DIFF_PREVIEWS.md)
 

--- a/crates/oyo/src/app/mod.rs
+++ b/crates/oyo/src/app/mod.rs
@@ -4,7 +4,8 @@ use crate::blame::BlameInfo;
 use crate::config::{
     BlameMode, DiffExtentMarkerMode, DiffExtentMarkerScope, DiffForegroundMode, DiffHighlightMode,
     FileCountMode, FilePanelPosition, FoldContextMode, HunkWrapMode, MentionFileScope,
-    MentionFinder, ModifiedStepMode, ResolvedTheme, StepWrapMode, SyntaxMode,
+    MentionFinder, ModifiedStepMode, ResolvedTheme, ReviewActionConfig, ReviewHookConfig,
+    StepWrapMode, SyntaxMode,
 };
 use crate::keybindings::Keybindings;
 use crate::syntax::{SyntaxCache, SyntaxEngine};
@@ -420,6 +421,12 @@ pub struct App {
     review_repo_file_cache: Option<Vec<String>>,
     /// Monotonic revision for review state changes (cache invalidation)
     review_revision: u64,
+    /// Commands run on review lifecycle events.
+    pub review_hooks: Vec<ReviewHookConfig>,
+    /// User-visible review commands.
+    pub review_actions: Vec<ReviewActionConfig>,
+    /// Non-fatal review hook warnings to print after TUI exits.
+    review_hook_warnings: Vec<String>,
     /// Last matched display index for search navigation
     search_last_target: Option<usize>,
     /// Pending scroll to a search target
@@ -703,6 +710,9 @@ impl App {
             review_mention_fzf_available: None,
             review_repo_file_cache: None,
             review_revision: 0,
+            review_hooks: Vec::new(),
+            review_actions: Vec::new(),
+            review_hook_warnings: Vec::new(),
             search_last_target: None,
             needs_scroll_to_search: false,
             search_target: None,

--- a/crates/oyo/src/app/palette.rs
+++ b/crates/oyo/src/app/palette.rs
@@ -17,6 +17,7 @@ pub(crate) enum PaletteAction {
     Quit,
     RefreshCurrentFile,
     RefreshAllFiles,
+    ReviewAction(usize),
 }
 
 #[derive(Clone, Debug)]
@@ -225,6 +226,26 @@ impl App {
             });
         }
 
+        if self.review_mode {
+            for (idx, action) in self.review_actions.iter().enumerate() {
+                let show = action.show.is_empty()
+                    || action.show.iter().any(|item| item == "command_palette");
+                if show {
+                    let label = if action.label.trim().is_empty() {
+                        action.id.clone()
+                    } else {
+                        action.label.clone()
+                    };
+                    if !label.trim().is_empty() {
+                        entries.push(PaletteEntry {
+                            label: format!("Review: {label}"),
+                            action: PaletteAction::ReviewAction(idx),
+                        });
+                    }
+                }
+            }
+        }
+
         entries.push(PaletteEntry {
             label: "Quit".to_string(),
             action: PaletteAction::Quit,
@@ -261,6 +282,7 @@ impl App {
             PaletteAction::Quit => self.should_quit = true,
             PaletteAction::RefreshCurrentFile => self.refresh_current_file(),
             PaletteAction::RefreshAllFiles => self.refresh_all_files(),
+            PaletteAction::ReviewAction(idx) => self.run_review_action(idx),
         }
     }
 

--- a/crates/oyo/src/app/review.rs
+++ b/crates/oyo/src/app/review.rs
@@ -1,5 +1,10 @@
 use super::{AnimationFrame, App, ViewMode};
-use crate::config::{MentionFileScope, MentionFinder};
+use crate::config::{
+    MentionFileScope, MentionFinder, ReviewActionConfig, ReviewHookConfig, ReviewHookEvent,
+    ReviewHookStdin,
+};
+use crossterm::event::KeyEvent;
+use keymap::{parser::parse_seq, ToKeyMap};
 use oyo_core::{ChangeKind, LineKind, ViewLine};
 use serde::{Deserialize, Serialize};
 use std::collections::{hash_map::DefaultHasher, BTreeSet};
@@ -7,7 +12,7 @@ use std::fs;
 use std::hash::{Hash, Hasher};
 use std::io::Write;
 use std::process::{Command, Stdio};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) enum ReviewTargetKind {
@@ -76,6 +81,41 @@ struct ReviewSession {
     editor: Option<ReviewEditorState>,
 }
 
+#[derive(Debug, Serialize)]
+struct ReviewExport<'a> {
+    version: u32,
+    event: &'static str,
+    repo_root: String,
+    session_file: Option<String>,
+    diff_fingerprint: String,
+    diff: ReviewExportDiff,
+    review: ReviewExportBody<'a>,
+}
+
+#[derive(Debug, Serialize)]
+struct ReviewExportDiff {
+    branch: Option<String>,
+    range: Option<(String, String)>,
+    files: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ReviewExportBody<'a> {
+    text: &'a str,
+    comments: Vec<ReviewExportComment<'a>>,
+}
+
+#[derive(Debug, Serialize)]
+struct ReviewExportComment<'a> {
+    id: u64,
+    file: &'a str,
+    kind: &'static str,
+    side: Option<&'static str>,
+    old_range: Option<ReviewRange>,
+    new_range: Option<ReviewRange>,
+    body: &'a str,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct ReviewEditorRender {
     pub(crate) title: String,
@@ -134,6 +174,40 @@ fn now_ts() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
+}
+
+fn review_event_name(event: ReviewHookEvent) -> &'static str {
+    event.as_str()
+}
+
+fn hook_label(config: &ReviewHookConfig) -> String {
+    if config.id.trim().is_empty() {
+        config.command.clone()
+    } else {
+        config.id.clone()
+    }
+}
+
+fn action_label(config: &ReviewActionConfig) -> String {
+    if config.label.trim().is_empty() {
+        config.id.clone()
+    } else {
+        config.label.clone()
+    }
+}
+
+fn action_shown(config: &ReviewActionConfig, place: &str) -> bool {
+    config.show.is_empty() || config.show.iter().any(|item| item == place)
+}
+
+fn key_matches_config(key: KeyEvent, binding: &str) -> bool {
+    let Ok(seq) = parse_seq(binding) else {
+        return false;
+    };
+    if seq.len() != 1 {
+        return false;
+    }
+    key.to_keymap().ok().as_ref() == seq.first()
 }
 
 fn hash_hex(value: &str) -> String {
@@ -398,6 +472,47 @@ impl App {
 
     pub fn review_comment_count(&self) -> usize {
         self.review_comments.len()
+    }
+
+    pub fn take_review_hook_warnings(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.review_hook_warnings)
+    }
+
+    pub fn review_action_labels_for_editor(&self) -> Vec<(String, String)> {
+        self.review_actions
+            .iter()
+            .filter(|action| action_shown(action, "review_editor"))
+            .filter_map(|action| {
+                let key = action.key.as_ref()?.trim();
+                (!key.is_empty()).then(|| (key.to_string(), action_label(action)))
+            })
+            .collect()
+    }
+
+    pub fn handle_review_action_key(&mut self, key: KeyEvent) -> bool {
+        let idx = self.review_actions.iter().position(|action| {
+            action_shown(action, "review_editor")
+                && action
+                    .key
+                    .as_deref()
+                    .is_some_and(|binding| key_matches_config(key, binding))
+        });
+        if let Some(idx) = idx {
+            self.run_review_action(idx);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn run_review_action(&mut self, idx: usize) {
+        let Some(action) = self.review_actions.get(idx).cloned() else {
+            return;
+        };
+        if action.save_editor && self.review_editor.is_some() {
+            self.review_save_editor();
+        }
+        self.run_review_action_command(&action);
     }
 
     pub fn review_editor_active(&self) -> bool {
@@ -844,6 +959,7 @@ impl App {
         self.review_next_comment_id = 1;
         self.touch_review_state();
         self.persist_review_session();
+        self.run_review_hooks(ReviewHookEvent::CommentsCleared, None);
         true
     }
 
@@ -1040,9 +1156,13 @@ impl App {
         if body.trim().is_empty() {
             if let Some(idx) = existing_idx {
                 self.review_comments.remove(idx);
+                self.touch_review_state();
+                self.persist_review_session();
+                self.run_review_hooks(ReviewHookEvent::CommentDeleted, None);
+            } else {
+                self.touch_review_state();
+                self.persist_review_session();
             }
-            self.touch_review_state();
-            self.persist_review_session();
             return;
         }
 
@@ -1067,6 +1187,7 @@ impl App {
 
         self.touch_review_state();
         self.persist_review_session();
+        self.run_review_hooks(ReviewHookEvent::CommentSaved, None);
     }
 
     pub fn submit_review_and_quit(&mut self) {
@@ -1075,6 +1196,7 @@ impl App {
         }
         self.review_mention_picker = None;
         let output = self.format_review_output();
+        self.run_review_hooks(ReviewHookEvent::ReviewReady, Some(&output));
         self.review_submission_output = Some(output);
         self.touch_review_state();
         self.persist_review_session();
@@ -1083,6 +1205,184 @@ impl App {
 
     pub fn take_review_submission_output(&mut self) -> Option<String> {
         self.review_submission_output.take()
+    }
+
+    fn run_review_hooks(&mut self, event: ReviewHookEvent, output: Option<&str>) {
+        let hooks: Vec<_> = self
+            .review_hooks
+            .iter()
+            .filter(|hook| hook.on == event)
+            .cloned()
+            .collect();
+        for hook in hooks {
+            self.run_review_hook_command(&hook, event, output);
+        }
+    }
+
+    fn run_review_action_command(&mut self, action: &ReviewActionConfig) {
+        let hook = ReviewHookConfig {
+            id: action.id.clone(),
+            on: action.on,
+            command: action.command.clone(),
+            args: action.args.clone(),
+            stdin: action.stdin,
+            blocking: action.blocking,
+            timeout_ms: action.timeout_ms,
+        };
+        let output = self.format_review_output();
+        self.run_review_hook_command(&hook, action.on, Some(&output));
+    }
+
+    fn run_review_hook_command(
+        &mut self,
+        hook: &ReviewHookConfig,
+        event: ReviewHookEvent,
+        output: Option<&str>,
+    ) {
+        if hook.command.trim().is_empty() {
+            return;
+        }
+        let payload = self.review_export_json(event, output);
+        let mut command = Command::new(&hook.command);
+        command.args(&hook.args);
+        if let Some(root) = self
+            .review_repo_root
+            .as_deref()
+            .filter(|root| !root.is_empty())
+        {
+            command.current_dir(root);
+            command.env("OYO_REPO_ROOT", root);
+        }
+        command.env("OYO_REVIEW_EVENT", review_event_name(event));
+        command.env("OYO_DIFF_FINGERPRINT", &self.review_diff_fingerprint);
+        if let Some(path) = self.review_session_path.as_ref() {
+            command.env("OYO_SESSION_FILE", path);
+        }
+        command.stdout(Stdio::null());
+        command.stderr(Stdio::null());
+        match hook.stdin {
+            ReviewHookStdin::Json => {
+                command.stdin(Stdio::piped());
+            }
+            ReviewHookStdin::None => {
+                command.stdin(Stdio::null());
+            }
+        }
+
+        let mut child = match command.spawn() {
+            Ok(child) => child,
+            Err(error) => {
+                self.review_hook_warnings.push(format!(
+                    "Review hook '{}' failed to start: {error}",
+                    hook_label(hook)
+                ));
+                return;
+            }
+        };
+
+        if matches!(hook.stdin, ReviewHookStdin::Json) {
+            if let Some(mut stdin) = child.stdin.take() {
+                if let Err(error) = stdin.write_all(payload.as_bytes()) {
+                    self.review_hook_warnings.push(format!(
+                        "Review hook '{}' failed to receive JSON: {error}",
+                        hook_label(hook)
+                    ));
+                }
+            }
+        }
+
+        if !hook.blocking {
+            std::thread::spawn(move || {
+                let _ = child.wait();
+            });
+            return;
+        }
+
+        let timeout = Duration::from_millis(hook.timeout_ms.max(1));
+        let started = Instant::now();
+        loop {
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    if !status.success() {
+                        self.review_hook_warnings.push(format!(
+                            "Review hook '{}' exited with status {status}",
+                            hook_label(hook)
+                        ));
+                    }
+                    return;
+                }
+                Ok(None) if started.elapsed() >= timeout => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    self.review_hook_warnings.push(format!(
+                        "Review hook '{}' timed out after {}ms",
+                        hook_label(hook),
+                        hook.timeout_ms
+                    ));
+                    return;
+                }
+                Ok(None) => std::thread::sleep(Duration::from_millis(20)),
+                Err(error) => {
+                    self.review_hook_warnings.push(format!(
+                        "Review hook '{}' failed while waiting: {error}",
+                        hook_label(hook)
+                    ));
+                    return;
+                }
+            }
+        }
+    }
+
+    fn review_export_json(&self, event: ReviewHookEvent, output: Option<&str>) -> String {
+        let output_owned;
+        let output = match output {
+            Some(output) => output,
+            None => {
+                output_owned = self.format_review_output();
+                &output_owned
+            }
+        };
+        let comments = self
+            .review_comments
+            .iter()
+            .map(|comment| ReviewExportComment {
+                id: comment.id,
+                file: &comment.anchor.file_path,
+                kind: match comment.anchor.kind {
+                    ReviewTargetKind::Line => "line",
+                    ReviewTargetKind::Hunk => "hunk",
+                },
+                side: comment.anchor.side.map(ReviewSide::as_str),
+                old_range: comment.anchor.old_range,
+                new_range: comment.anchor.new_range,
+                body: &comment.body,
+            })
+            .collect();
+        let export = ReviewExport {
+            version: 1,
+            event: review_event_name(event),
+            repo_root: self.review_repo_root.clone().unwrap_or_default(),
+            session_file: self
+                .review_session_path
+                .as_ref()
+                .map(|path| path.to_string_lossy().to_string()),
+            diff_fingerprint: self.review_diff_fingerprint.clone(),
+            diff: ReviewExportDiff {
+                branch: self.git_branch.clone(),
+                range: self.multi_diff.git_range_display(),
+                files: self
+                    .multi_diff
+                    .files
+                    .iter()
+                    .map(|file| file.display_name.clone())
+                    .collect(),
+            },
+            review: ReviewExportBody {
+                text: output,
+                comments,
+            },
+        };
+        serde_json::to_string_pretty(&export).unwrap_or_else(|_| "{}".to_string())
     }
 
     fn touch_review_state(&mut self) {
@@ -1098,6 +1398,7 @@ impl App {
             self.review_comments.remove(idx);
             self.touch_review_state();
             self.persist_review_session();
+            self.run_review_hooks(ReviewHookEvent::CommentDeleted, None);
             true
         } else {
             false
@@ -1976,7 +2277,46 @@ impl App {
 
 #[cfg(test)]
 mod tests {
-    use super::preserve_ref_trailing_space;
+    use super::*;
+    use crate::app::ViewMode;
+    use oyo_core::MultiFileDiff;
+    use std::path::Path;
+
+    fn temp_path(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "oyo-review-hook-{name}-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    fn write_file(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, content).unwrap();
+    }
+
+    fn test_app() -> App {
+        let diff = MultiFileDiff::from_file_pair(
+            "old.txt".into(),
+            "new.txt".into(),
+            "old\n".to_string(),
+            "new\n".to_string(),
+        );
+        let mut app = App::new(
+            diff,
+            ViewMode::UnifiedPane,
+            0,
+            false,
+            Some("branch".to_string()),
+        );
+        app.enable_review_mode();
+        app
+    }
 
     #[test]
     fn preserve_space_for_trailing_line_reference() {
@@ -1997,5 +2337,120 @@ mod tests {
         assert!(!preserve_ref_trailing_space("@ "));
         assert!(!preserve_ref_trailing_space("no trailing space"));
         assert!(!preserve_ref_trailing_space("ends with tab\t"));
+    }
+
+    #[test]
+    fn review_export_json_contains_comments() {
+        let mut app = test_app();
+        app.review_comments.push(ReviewComment {
+            id: 7,
+            anchor: ReviewAnchor {
+                file_index: 0,
+                file_path: "new.txt".to_string(),
+                kind: ReviewTargetKind::Line,
+                side: Some(ReviewSide::New),
+                old_range: None,
+                new_range: Some(ReviewRange { start: 1, end: 1 }),
+                hunk_id: Some(0),
+                display_idx_hint: Some(0),
+                anchor_key: "line|new.txt|new|1".to_string(),
+            },
+            body: "please fix".to_string(),
+            created_at: 1,
+            updated_at: 1,
+        });
+
+        let json = app.review_export_json(ReviewHookEvent::ReviewReady, None);
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["event"], "review_ready");
+        assert_eq!(value["diff"]["branch"], "branch");
+        assert_eq!(value["review"]["comments"][0]["file"], "new.txt");
+        assert_eq!(value["review"]["comments"][0]["body"], "please fix");
+    }
+
+    #[test]
+    fn review_action_key_runs_command_and_shows_label() {
+        let root = temp_path("action");
+        let hook_path = root.join("hook.sh");
+        let out_path = root.join("action.json");
+        write_file(
+            &hook_path,
+            &format!("#!/bin/sh\ncat > '{}'\n", out_path.display()),
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&hook_path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&hook_path, perms).unwrap();
+        }
+
+        let mut app = test_app();
+        app.review_actions = vec![ReviewActionConfig {
+            id: "capture-action".to_string(),
+            label: "Capture".to_string(),
+            key: Some("ctrl-g".to_string()),
+            on: ReviewHookEvent::ReviewReady,
+            command: hook_path.to_string_lossy().to_string(),
+            args: Vec::new(),
+            stdin: ReviewHookStdin::Json,
+            blocking: true,
+            timeout_ms: 5_000,
+            save_editor: true,
+            show: vec!["review_editor".to_string()],
+        }];
+
+        assert_eq!(
+            app.review_action_labels_for_editor(),
+            vec![("ctrl-g".to_string(), "Capture".to_string())]
+        );
+        assert!(app.handle_review_action_key(KeyEvent::new(
+            crossterm::event::KeyCode::Char('g'),
+            crossterm::event::KeyModifiers::CONTROL,
+        )));
+
+        let payload = std::fs::read_to_string(&out_path).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(value["event"], "review_ready");
+        assert!(app.take_review_hook_warnings().is_empty());
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn review_ready_hook_receives_json() {
+        let root = temp_path("ready");
+        let hook_path = root.join("hook.sh");
+        let out_path = root.join("payload.json");
+        write_file(
+            &hook_path,
+            &format!("#!/bin/sh\ncat > '{}'\n", out_path.display()),
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&hook_path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&hook_path, perms).unwrap();
+        }
+
+        let mut app = test_app();
+        app.review_hooks = vec![ReviewHookConfig {
+            id: "capture".to_string(),
+            on: ReviewHookEvent::ReviewReady,
+            command: hook_path.to_string_lossy().to_string(),
+            args: Vec::new(),
+            stdin: ReviewHookStdin::Json,
+            blocking: true,
+            timeout_ms: 5_000,
+        }];
+        app.submit_review_and_quit();
+
+        let payload = std::fs::read_to_string(&out_path).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(value["event"], "review_ready");
+        assert!(app.take_review_hook_warnings().is_empty());
+
+        let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/crates/oyo/src/config.rs
+++ b/crates/oyo/src/config.rs
@@ -57,6 +57,12 @@
 //! file_scope = "repo" # changed | repo
 //! finder = "auto"     # auto | builtin | fzf
 //!
+//! [[review.hooks]]
+//! id = "review-ready"
+//! on = "review_ready"
+//! command = ".oyo/hooks/review-ready"
+//! stdin = "json"
+//!
 //! [editor]
 //! # command = "nvim"
 //! # args = ["+{line}", "{file}"]
@@ -1420,6 +1426,120 @@ pub struct CommentsConfig {
     pub mentions: MentionConfig,
 }
 
+#[derive(Debug, Deserialize, Clone, Copy, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewHookEvent {
+    CommentSaved,
+    CommentDeleted,
+    CommentsCleared,
+    #[default]
+    ReviewReady,
+}
+
+impl ReviewHookEvent {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::CommentSaved => "comment_saved",
+            Self::CommentDeleted => "comment_deleted",
+            Self::CommentsCleared => "comments_cleared",
+            Self::ReviewReady => "review_ready",
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, Default, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewHookStdin {
+    #[default]
+    Json,
+    None,
+}
+
+fn default_hook_stdin() -> ReviewHookStdin {
+    ReviewHookStdin::Json
+}
+
+fn default_hook_blocking() -> bool {
+    true
+}
+
+fn default_hook_timeout_ms() -> u64 {
+    30_000
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct ReviewHookConfig {
+    pub id: String,
+    pub on: ReviewHookEvent,
+    pub command: String,
+    pub args: Vec<String>,
+    #[serde(default = "default_hook_stdin")]
+    pub stdin: ReviewHookStdin,
+    #[serde(default = "default_hook_blocking")]
+    pub blocking: bool,
+    #[serde(default = "default_hook_timeout_ms")]
+    pub timeout_ms: u64,
+}
+
+impl Default for ReviewHookConfig {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            on: ReviewHookEvent::ReviewReady,
+            command: String::new(),
+            args: Vec::new(),
+            stdin: ReviewHookStdin::Json,
+            blocking: true,
+            timeout_ms: default_hook_timeout_ms(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
+pub struct ReviewActionConfig {
+    pub id: String,
+    pub label: String,
+    pub key: Option<String>,
+    pub on: ReviewHookEvent,
+    pub command: String,
+    pub args: Vec<String>,
+    #[serde(default = "default_hook_stdin")]
+    pub stdin: ReviewHookStdin,
+    #[serde(default = "default_hook_blocking")]
+    pub blocking: bool,
+    #[serde(default = "default_hook_timeout_ms")]
+    pub timeout_ms: u64,
+    pub save_editor: bool,
+    pub show: Vec<String>,
+}
+
+impl Default for ReviewActionConfig {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            label: String::new(),
+            key: None,
+            on: ReviewHookEvent::ReviewReady,
+            command: String::new(),
+            args: Vec::new(),
+            stdin: ReviewHookStdin::Json,
+            blocking: true,
+            timeout_ms: default_hook_timeout_ms(),
+            save_editor: true,
+            show: vec!["command_palette".to_string(), "review_editor".to_string()],
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone, Default)]
+#[serde(default)]
+pub struct ReviewConfig {
+    pub hooks: Vec<ReviewHookConfig>,
+    pub actions: Vec<ReviewActionConfig>,
+}
+
 /// User keybinding overrides grouped by keybinding mode.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct KeybindingsConfig {
@@ -1484,6 +1604,7 @@ pub struct Config {
     pub navigation: NavigationConfig,
     pub no_step: NoStepConfig,
     pub comments: CommentsConfig,
+    pub review: ReviewConfig,
     pub editor: EditorConfig,
     pub keybindings: KeybindingsConfig,
 }

--- a/crates/oyo/src/input.rs
+++ b/crates/oyo/src/input.rs
@@ -153,6 +153,9 @@ fn handle_help_key(app: &mut App, key: KeyEvent) {
 }
 
 fn handle_review_editor_key(app: &mut App, key: KeyEvent) {
+    if app.handle_review_action_key(key) {
+        return;
+    }
     match app.keybindings.review_editor(key) {
         Dispatch::Matched(ReviewEditorAction::Cancel) => {
             if !app.review_cancel_mention_picker() {

--- a/crates/oyo/src/main.rs
+++ b/crates/oyo/src/main.rs
@@ -776,6 +776,8 @@ fn apply_config_to_app(app: &mut App, config: &config::Config, args: &Args, ligh
     app.no_step_auto_jump_on_enter = config.no_step.auto_jump_on_enter;
     app.review_mention_file_scope = config.comments.mentions.file_scope;
     app.review_mention_finder = config.comments.mentions.finder;
+    app.review_hooks = config.review.hooks.clone();
+    app.review_actions = config.review.actions.clone();
     app.hunk_wrap = config.navigation.wrap.hunk;
     app.step_wrap = config.navigation.wrap.step;
     app.primary_marker = config.ui.primary_marker.clone();
@@ -1166,6 +1168,7 @@ fn main() -> Result<()> {
 
         let mut exit_message: Option<String> = None;
         let mut review_output: Option<String> = None;
+        let mut review_hook_warnings = Vec::new();
         loop {
             let empty_message = match &input_mode {
                 InputMode::GitUncommitted => Some("No uncommitted changes found.".to_string()),
@@ -1204,6 +1207,7 @@ fn main() -> Result<()> {
             if review_output.is_none() {
                 review_output = app.take_review_submission_output();
             }
+            review_hook_warnings.extend(app.take_review_hook_warnings());
             match exit {
                 AppExit::Quit => break,
                 AppExit::OpenDashboard => {
@@ -1228,6 +1232,9 @@ fn main() -> Result<()> {
             args.review_output_file.as_ref(),
             !args.no_print_review,
         )?;
+        for warning in review_hook_warnings {
+            eprintln!("Warning: {warning}");
+        }
         if let Some(message) = exit_message {
             println!("{message}");
         }
@@ -1273,6 +1280,7 @@ fn main() -> Result<()> {
 
     let mut exit_message: Option<String> = None;
     let mut review_output: Option<String> = None;
+    let mut review_hook_warnings = Vec::new();
     let mut pending_diff = Some(prefetched);
     loop {
         let empty_message = match &input_mode {
@@ -1315,6 +1323,7 @@ fn main() -> Result<()> {
         if review_output.is_none() {
             review_output = app.take_review_submission_output();
         }
+        review_hook_warnings.extend(app.take_review_hook_warnings());
         match exit {
             AppExit::Quit => break,
             AppExit::OpenDashboard => {
@@ -1341,6 +1350,9 @@ fn main() -> Result<()> {
         args.review_output_file.as_ref(),
         !args.no_print_review,
     )?;
+    for warning in review_hook_warnings {
+        eprintln!("Warning: {warning}");
+    }
     if let Some(message) = exit_message {
         println!("{message}");
     }

--- a/crates/oyo/src/ui.rs
+++ b/crates/oyo/src/ui.rs
@@ -1684,6 +1684,24 @@ fn draw_review_editor_overlay(frame: &mut Frame, app: &mut App) {
 
     frame.render_widget(Clear, popup_area);
 
+    let mut footer_parts = vec![
+        format!(
+            "{} save",
+            app.keybindings.review_editor_keys(ReviewEditorAction::Save)
+        ),
+        format!(
+            "{} cancel",
+            app.keybindings
+                .review_editor_keys(ReviewEditorAction::Cancel)
+        ),
+        "@ mention".to_string(),
+    ];
+    footer_parts.extend(
+        app.review_action_labels_for_editor()
+            .into_iter()
+            .map(|(key, label)| format!("{key} {label}")),
+    );
+
     let mut block = Block::default()
         .title(Span::styled(
             editor.title,
@@ -1692,12 +1710,7 @@ fn draw_review_editor_overlay(frame: &mut Frame, app: &mut App) {
                 .add_modifier(Modifier::BOLD),
         ))
         .title_bottom(Span::styled(
-            format!(
-                " {} save • {} cancel • @ mention ",
-                app.keybindings.review_editor_keys(ReviewEditorAction::Save),
-                app.keybindings
-                    .review_editor_keys(ReviewEditorAction::Cancel)
-            ),
+            format!(" {} ", footer_parts.join(" | ")),
             Style::default().fg(app.theme.text_muted),
         ))
         .borders(Borders::ALL)

--- a/docs/REVIEW_HOOKS.md
+++ b/docs/REVIEW_HOOKS.md
@@ -1,0 +1,189 @@
+# Review hooks
+
+Use review hooks to run your own commands when review comments change, or when the final review is ready.
+
+Oyo sends a JSON payload to hooks by default. This lets you connect Oyo to other tools without adding those tools to Oyo.
+
+## Choose a hook or an action
+
+Use a hook when Oyo should run the command automatically.
+
+Use an action when you want to run the command yourself from the UI. Actions can appear in the review editor footer and in the command palette.
+
+## Events
+
+| Event | When it runs |
+| --- | --- |
+| `comment_saved` | A line or hunk comment is saved or updated |
+| `comment_deleted` | A comment is removed |
+| `comments_cleared` | All comments are cleared |
+| `review_ready` | You quit and review output is ready |
+
+## Add an automatic hook
+
+```toml
+[[review.hooks]]
+id = "archive-review"
+on = "review_ready"
+command = ".oyo/hooks/archive-review"
+stdin = "json"
+blocking = true
+timeout_ms = 30000
+```
+
+This runs `.oyo/hooks/archive-review` when review output is ready.
+
+`command` is the executable to run. It is not a shell string. Put flags and other arguments in `args`:
+
+```toml
+command = ".oyo/hooks/archive-review"
+args = ["--format", "json"]
+```
+
+Do not write this:
+
+```toml
+command = ".oyo/hooks/archive-review --format json"
+```
+
+If you need shell features, run a shell yourself:
+
+```toml
+command = "sh"
+args = ["-c", ".oyo/hooks/archive-review --format json"]
+```
+
+## Hook fields
+
+| Field | Meaning |
+| --- | --- |
+| `id` | Name used in warning messages |
+| `on` | Event that runs the hook |
+| `command` | Executable to run directly |
+| `args` | Arguments passed to the command |
+| `stdin` | `json` sends the payload, `none` sends nothing |
+| `blocking` | `true` waits for the command to finish |
+| `timeout_ms` | Maximum wait time when `blocking = true` |
+
+Most hooks only need `id`, `on` and `command`.
+
+## Add a review action
+
+Use an action when you want a visible command.
+
+```toml
+[[review.actions]]
+id = "save-review-json"
+label = "Save review"
+key = "ctrl-r"
+on = "review_ready"
+command = ".oyo/hooks/save-review"
+args = ["reviews/latest.json"]
+stdin = "json"
+blocking = true
+timeout_ms = 30000
+save_editor = true
+show = ["review_editor", "command_palette"]
+```
+
+This adds a `ctrl-r` action in the review editor. It can also appear in the command palette.
+
+## Action fields
+
+| Field | Meaning |
+| --- | --- |
+| `id` | Stable action name |
+| `label` | Text shown in the UI |
+| `key` | Optional key handled in the review editor |
+| `on` | Event name included in the JSON payload |
+| `command` | Executable to run directly |
+| `args` | Arguments passed to the command |
+| `stdin` | `json` sends the payload, `none` sends nothing |
+| `blocking` | `true` waits for the command to finish |
+| `timeout_ms` | Maximum wait time when `blocking = true` |
+| `save_editor` | Save active editor text before running |
+| `show` | Use `review_editor`, `command_palette`, or both |
+
+## What Oyo sends
+
+Oyo sends this shape when `stdin = "json"`:
+
+```json
+{
+  "version": 1,
+  "event": "review_ready",
+  "repo_root": "/repo",
+  "session_file": "/tmp/oyo/review/.../abc.json",
+  "diff_fingerprint": "abc",
+  "diff": {
+    "branch": "feature",
+    "range": ["main", "HEAD"],
+    "files": ["src/lib.rs"]
+  },
+  "review": {
+    "text": "=== Comment 1 ===\n...",
+    "comments": [
+      {
+        "id": 1,
+        "file": "src/lib.rs",
+        "kind": "line",
+        "side": "new",
+        "old_range": null,
+        "new_range": { "start": 42, "end": 42 },
+        "body": "Please fix this."
+      }
+    ]
+  }
+}
+```
+
+The payload is versioned. Check `version` before you depend on the payload shape. Oyo will bump the version if it makes a breaking payload change.
+
+`side` is `old` or `new`. Hunk comments may include both `old_range` and `new_range`.
+
+Oyo also sets these environment variables:
+
+- `OYO_REVIEW_EVENT`
+- `OYO_REPO_ROOT`
+- `OYO_DIFF_FINGERPRINT`
+- `OYO_SESSION_FILE`
+
+Hooks run from the repo root when Oyo knows it.
+
+## Blocking and warnings
+
+If `blocking = true`, Oyo waits for the command to finish. It reports non-zero exits and timeouts after the terminal UI exits.
+
+If `blocking = false`, Oyo starts the command and returns immediately. Use this only for fire-and-forget work. Oyo does not report the command exit status.
+
+Oyo hides hook stdout and stderr.
+
+## Start with a small script
+
+Start with a script that writes the payload to a file:
+
+```sh
+#!/bin/sh
+set -eu
+
+out="${1:-review.json}"
+mkdir -p "$(dirname "$out")"
+cat > "$out"
+```
+
+Then configure an action:
+
+```toml
+[[review.actions]]
+id = "save-review-json"
+label = "Save review"
+key = "ctrl-r"
+on = "review_ready"
+command = ".oyo/hooks/save-review"
+args = ["reviews/latest.json"]
+stdin = "json"
+blocking = true
+show = ["review_editor", "command_palette"]
+```
+
+Use an automatic hook after the script works as expected.


### PR DESCRIPTION
This pull request introduces a new system for user-defined review hooks and actions.  Users can now configure external commands to automatically run during review events like saving comments or finalising a review.  Additionally, custom actions can be exposed in the UI, such as the review editor and command palette.  The configuration and documentation have been updated to support these features, facilitating integrations with external tools and workflows.